### PR TITLE
fix(scopes): make source_record_ids cross-db portable

### DIFF
--- a/macros/final-tables/finalize_scope.sql
+++ b/macros/final-tables/finalize_scope.sql
@@ -23,6 +23,12 @@
   The CTE must produce exactly the columns above. finalize_scope adds
   scope_id, scope_name, is_active, _created_at, _updated_at, _processed_at.
 
+  `source_record_ids` is a STRING (semicolon-delimited list of provenance
+  IDs — relationship_ids, trait_ids, etc.) rather than an ARRAY so the
+  contract is portable across BigQuery and Snowflake. Use `concat(a, ';',
+  b)` to join multiple IDs; pass an empty string or NULL when there is
+  no provenance to record.
+
   source_cte defaults to 'raw_scope_tuples' but can be overridden.
 #}
 

--- a/models/core/nexus.yml
+++ b/models/core/nexus.yml
@@ -230,8 +230,10 @@ models:
           authenticated user's session role at query time."
       - name: source_record_ids
         description:
-          "Array of source record IDs (relationship_id, trait_id, etc.)
-          that produced this grant; for audit/lineage."
+          "Semicolon-delimited source record IDs (relationship_id,
+          trait_id, etc.) that produced this grant; for audit/lineage.
+          STRING-typed for cross-warehouse portability — BigQuery and
+          Snowflake disagree on array literal syntax."
       - name: granted_at
         description: "When the grant was first observed"
       - name: revoked_at

--- a/models/core/nexus_scopes.sql
+++ b/models/core/nexus_scopes.sql
@@ -29,7 +29,7 @@ select
     cast(null as {{ dbt.type_string() }}) as resource_entity_type,
     cast(null as {{ dbt.type_string() }}) as relationship,
     cast(null as {{ dbt.type_string() }}) as role,
-    cast(null as array<{{ dbt.type_string() }}>) as source_record_ids,
+    cast(null as {{ dbt.type_string() }}) as source_record_ids,
     cast(null as timestamp) as granted_at,
     cast(null as timestamp) as revoked_at,
     cast(false as boolean) as is_active,

--- a/models/core/nexus_scopes.sql
+++ b/models/core/nexus_scopes.sql
@@ -20,6 +20,9 @@
 
 {% if scope_models | length == 0 %}
 
+-- Empty stub: zero rows but the full contract column shape. The
+-- `where 1 = 0` filter needs a FROM in BigQuery and Snowflake, so we
+-- select from a one-row dummy and immediately filter it out.
 select
     cast(null as {{ dbt.type_string() }}) as scope_id,
     cast(null as {{ dbt.type_string() }}) as scope_name,
@@ -36,6 +39,7 @@ select
     cast(null as timestamp) as _created_at,
     cast(null as timestamp) as _updated_at,
     cast(null as timestamp) as _processed_at
+from (select 1) _empty_scopes_stub
 where 1 = 0
 
 {% else %}


### PR DESCRIPTION
## Summary

Changes the \`source_record_ids\` column on the scope contract from \`ARRAY<STRING>\` to \`STRING\` (semicolon-delimited). BigQuery and Snowflake disagree on array literal syntax and on array-casting; a STRING column with a delimiter convention is portable.

## What changed

- **\`nexus_scopes\` empty stub** — projects that don't declare \`nexus_scope_models\` compile this path. Previously used \`cast(null as array<STRING>)\` (BigQuery-only). Now \`cast(null as STRING)\`. Lets Snowflake clients consuming dbt-nexus build cleanly.
- **\`finalize_scope\` macro docs** — calls out the new convention.
- **\`nexus.yml\`** — column description updated.

## Caller migration

Scope models that previously emitted array literals need a tiny update:

| Before | After |
|---|---|
| \`[rel.relationship_id] as source_record_ids\` | \`rel.relationship_id as source_record_ids\` |
| \`array_concat(a, [b]) as source_record_ids\` | \`concat(a, ';', b) as source_record_ids\` |
| \`cast([] as array<STRING>) as source_record_ids\` | \`cast(null as STRING) as source_record_ids\` |

\`concat()\` works on both BigQuery and Snowflake.

The austin-wealth scope models (currently the only production callers) get the matching update in slide-rule-tech/nexus#261.

## Test plan

- [x] AWM rebuild on BigQuery: 47/47 build + tests pass (\`dbt build --select nexus_auth_identities nexus_scopes nexus_scope_*\`)
- [ ] Snowflake client: no current dbt-nexus consumer is Snowflake, but the syntax (\`cast(null as STRING)\`, \`concat(a, ';', b)\`) is documented as supported by both adapters
- [ ] Tag a v0.9.1 patch release after merge

## Backstory

This came up while wiring austin-wealth's permission scoping end-to-end. The wildcard admin row (\`viewer_entity_id = '*'\`) and the seedless admin scope landed alongside this, but those changes are in the consuming repo (austin-wealth's scope models). This PR is just the dbt-nexus side: make the contract column type portable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)