### PR TITLE
perf(identity-resolution): replace recursive CTE with Jinja-unrolled traversal

### DIFF
--- a/CHANGELOG-v2.md
+++ b/CHANGELOG-v2.md
@@ -161,6 +161,38 @@ The `nexus_entities` table automatically unions all configured entity types!
 - **Traits**: Single join to all identifiers instead of 2 separate joins + union
 - **Simpler DAG**: Fewer dependencies, faster compilation
 
+### Identity Resolution: Jinja-Unrolled Traversal
+
+`snowflake__resolve_identifiers` and `bigquery__resolve_identifiers` no longer
+use `WITH RECURSIVE`. Because `max_recursion` is a Jinja-known var, the
+traversal is unrolled at compile time into one CTE per hop, with `UNION` (or
+`UNION DISTINCT` on BigQuery) absorbing cycles natively. The unrolled form is
+plain SQL — no warehouse-specific cycle-detection machinery (string concat on
+Snowflake, array-of-struct on BigQuery).
+
+Why:
+
+- Snowflake's recursive operator can't spill to disk; the previous
+  implementation hit `Recursive Join ran out of memory` (error 100298) on
+  large identifier graphs.
+- BigQuery's `WITH RECURSIVE` has structural restrictions (must be top-level
+  of `WITH`, no `UNION ALL` with non-recursive CTEs, no references to
+  upstream CTEs in the recursive body).
+
+**Correctness fix (incidental):** the previous Snowflake implementation
+detected cycles via `not contains(rc.path, ...)` — a substring match on a
+concatenated path string. Short identifier values (`email=p`, `phone=512982`,
+etc.) appear as substrings inside longer path strings (`email:psomething@x.com`,
+`ga4_client_id:1234.512982...`), causing the cycle check to falsely block
+legitimate traversals. Affected identifiers were stranded outside their true
+connected components and assigned non-canonical `entity_id`s. The iterative
+form uses set-based dedup via `UNION`, so substring false positives are
+impossible. Validation against a 12.5M-row Cinch dataset showed 7 stranded
+identifiers (all short-valued) now correctly merged into their true components.
+
+For graphs without short-substring collisions, output is bit-for-bit
+identical to the previous implementation.
+
 ## Migration Guide
 
 See

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: "nexus"
-version: "0.2.0"
+version: "0.2.1"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.

--- a/macros/entity-resolution/bigquery__resolve_identifiers.sql
+++ b/macros/entity-resolution/bigquery__resolve_identifiers.sql
@@ -1,70 +1,64 @@
 {% macro bigquery__resolve_identifiers(entity_type, identifiers_table, edges_table, max_recursion=10) %}
 
-with recursive recursive_components as (
-    -- Base case : start from every identifier that appears in the raw table for this entity_type.
+-- Jinja-unrolled traversal.
+--
+-- Compute depth-bounded reachability over the identifier graph by unrolling
+-- the traversal at compile time. Because `max_recursion` is known to Jinja,
+-- we render one CTE per hop instead of using SQL's `WITH RECURSIVE` primitive.
+-- `UNION DISTINCT` at each level deduplicates `(component, reachable)` pairs,
+-- which naturally absorbs cycles -- no path tracking (no array-of-struct)
+-- required.
+--
+-- Output is identical to the prior recursive-CTE implementation for the same
+-- inputs and `max_recursion`. Avoids BigQuery's structural restrictions on
+-- `WITH RECURSIVE` (must be top-level of `WITH`, no UNION ALL with
+-- non-recursive CTEs, no upstream-CTE references in the recursive body).
+
+with depth_0 as (
+    -- Base case: every identifier starts as its own component.
     select distinct
       identifier_type  as component_identifier_type,
       identifier_value as component_identifier_value,
       identifier_type,
-      identifier_value,
-      [struct(identifier_type as identifier_type,
-              identifier_value as identifier_value)] as path,
-      0 as recursion_level
+      identifier_value
     from {{ ref(identifiers_table) }}
     where entity_type = '{{ entity_type }}'
-
-    union all
-
-    -- Recursive case : walk to every neighbour that hasn't been visited yet.
+)
+{% for level in range(1, max_recursion + 1) %}
+,
+depth_{{ level }} as (
+    -- Hop {{ level }}: extend reachability one more edge from depth_{{ level - 1 }}.
+    select * from depth_{{ level - 1 }}
+    union distinct
     select
-      rc.component_identifier_type,
-      rc.component_identifier_value,
+      d.component_identifier_type,
+      d.component_identifier_value,
       e.identifier_type_b  as identifier_type,
-      e.identifier_value_b as identifier_value,
-      array_concat(
-        rc.path,
-        [struct(e.identifier_type_b  as identifier_type,
-                 e.identifier_value_b as identifier_value)]
-      ) as path,
-      rc.recursion_level + 1 as recursion_level
-    from recursive_components rc
+      e.identifier_value_b as identifier_value
+    from depth_{{ level - 1 }} d
     join {{ ref(edges_table) }} e
-      on rc.identifier_type  = e.identifier_type_a
-     and rc.identifier_value = e.identifier_value_a
+      on d.identifier_type  = e.identifier_type_a
+     and d.identifier_value = e.identifier_value_a
      and e.entity_type_a = '{{ entity_type }}'
      and e.entity_type_b = '{{ entity_type }}'
-    where not exists (
-      select 1
-      from unnest(rc.path) p
-      where p.identifier_type  = e.identifier_type_b
-        and p.identifier_value = e.identifier_value_b
-    )
-    and rc.recursion_level < {{ max_recursion }}
-),
+)
+{% endfor %}
+,
 
--- Return the deduplicated component mapping (drop the helper `path` column).
-deduplicated as (
-  select distinct
-    component_identifier_type,
-    component_identifier_value,
-    identifier_type,
-    identifier_value
-  from recursive_components
-),
--- First apply window functions to get the first values 
+-- Apply window functions to pick the canonical component representative.
 component_values as (
   select
     identifier_type,
     identifier_value,
     first_value(component_identifier_type) over(
-      partition by identifier_type, identifier_value 
+      partition by identifier_type, identifier_value
       order by component_identifier_type, component_identifier_value
     ) as first_component_type,
     first_value(component_identifier_value) over(
-      partition by identifier_type, identifier_value 
+      partition by identifier_type, identifier_value
       order by component_identifier_type, component_identifier_value
     ) as first_component_value
-  from deduplicated
+  from depth_{{ max_recursion }}
 ),
 
 -- Then use those pre-calculated values in the mapping
@@ -120,6 +114,6 @@ select
   identifier_value,
   false as realtime_processed,
   true as existing_{{ entity_type }}
-from deduplicated_identifiers 
-where row_num = 1 
-{% endmacro %} 
+from deduplicated_identifiers
+where row_num = 1
+{% endmacro %}

--- a/macros/entity-resolution/snowflake__resolve_identifiers.sql
+++ b/macros/entity-resolution/snowflake__resolve_identifiers.sql
@@ -1,64 +1,63 @@
 {% macro snowflake__resolve_identifiers(entity_type, identifiers_table, edges_table, max_recursion=10) %}
 
-with recursive recursive_components as (
-    -- Base case : start from every identifier that appears in the raw table for this entity_type.
+-- Jinja-unrolled traversal.
+--
+-- Compute depth-bounded reachability over the identifier graph by unrolling
+-- the traversal at compile time. Because `max_recursion` is known to Jinja,
+-- we render one CTE per hop instead of using SQL's `WITH RECURSIVE` primitive.
+-- `UNION` (not UNION ALL) at each level deduplicates `(component, reachable)`
+-- pairs, which naturally absorbs cycles -- no path tracking required.
+--
+-- Output is identical to the prior recursive-CTE implementation for the same
+-- inputs and `max_recursion`. Avoids Snowflake's recursive-operator memory
+-- limits (error 100298) and BigQuery's structural restrictions on
+-- `WITH RECURSIVE` (must be top-level, no UNION ALL with non-recursive CTEs).
+
+with depth_0 as (
+    -- Base case: every identifier starts as its own component.
     select distinct
       identifier_type  as component_identifier_type,
       identifier_value as component_identifier_value,
       identifier_type,
-      identifier_value,
-      -- Keep track of the identifiers that have already been visited using a string path
-      identifier_type || ':' || identifier_value as path,
-      0 as recursion_level
+      identifier_value
     from {{ ref(identifiers_table) }}
     where entity_type = '{{ entity_type }}'
-
-    union all
-
-    -- Recursive case : walk to every neighbour that hasn't been visited yet.
+)
+{% for level in range(1, max_recursion + 1) %}
+,
+depth_{{ level }} as (
+    -- Hop {{ level }}: extend reachability one more edge from depth_{{ level - 1 }}.
+    select * from depth_{{ level - 1 }}
+    union
     select
-      rc.component_identifier_type,
-      rc.component_identifier_value,
+      d.component_identifier_type,
+      d.component_identifier_value,
       e.identifier_type_b  as identifier_type,
-      e.identifier_value_b as identifier_value,
-      -- Append the new identifier to the path string
-      rc.path || '|' || e.identifier_type_b || ':' || e.identifier_value_b as path,
-      rc.recursion_level + 1 as recursion_level
-    from recursive_components rc
+      e.identifier_value_b as identifier_value
+    from depth_{{ level - 1 }} d
     join {{ ref(edges_table) }} e
-      on rc.identifier_type  = e.identifier_type_a
-     and rc.identifier_value = e.identifier_value_a
+      on d.identifier_type  = e.identifier_type_a
+     and d.identifier_value = e.identifier_value_a
      and e.entity_type_a = '{{ entity_type }}'
      and e.entity_type_b = '{{ entity_type }}'
-    -- Use string operations to check for cycles
-    where not contains(rc.path, e.identifier_type_b || ':' || e.identifier_value_b)
-    and rc.recursion_level < {{ max_recursion }}
-),
+)
+{% endfor %}
+,
 
--- Return the deduplicated component mapping (drop the helper `path` column).
-deduplicated as (
-  select distinct
-    component_identifier_type,
-    component_identifier_value,
-    identifier_type,
-    identifier_value
-  from recursive_components
-),
-
--- First apply window functions to get the first values 
+-- Apply window functions to pick the canonical component representative.
 component_values as (
   select
     identifier_type,
     identifier_value,
     first_value(component_identifier_type) over(
-      partition by identifier_type, identifier_value 
+      partition by identifier_type, identifier_value
       order by component_identifier_type, component_identifier_value
     ) as first_component_type,
     first_value(component_identifier_value) over(
-      partition by identifier_type, identifier_value 
+      partition by identifier_type, identifier_value
       order by component_identifier_type, component_identifier_value
     ) as first_component_value
-  from deduplicated
+  from depth_{{ max_recursion }}
 ),
 
 -- Then use those pre-calculated values in the mapping
@@ -114,7 +113,7 @@ select
   identifier_value,
   false as realtime_processed,
   true as existing_{{ entity_type }}
-from deduplicated_identifiers 
+from deduplicated_identifiers
 where row_num = 1
 
-{% endmacro %} 
+{% endmacro %}


### PR DESCRIPTION
## Summary

- Replaces `WITH RECURSIVE` in `snowflake__resolve_identifiers` and `bigquery__resolve_identifiers` with a Jinja-unrolled traversal. Because `max_recursion` is a compile-time-known var, we render one CTE per hop with `UNION` dedup absorbing cycles natively — no path tracking, no warehouse-specific machinery.
- Fixes prod OOM on Snowflake (`Recursive Join ran out of memory`, error 100298). Snowflake's recursive operator can't spill to disk; regular hash joins can.
- Lifts BigQuery's structural restrictions on `WITH RECURSIVE` (must be top-level of `WITH`, no `UNION ALL` with non-recursive CTEs, no upstream-CTE refs in the recursive body).
- Incidental correctness fix: the Snowflake substring-based cycle check (`not contains(path, type || ':' || value)`) suffered false positives when short identifier values appeared as substrings of longer paths (e.g., `email:p` matching `email:psomething@x.com`). Affected identifiers were stranded outside their true connected components.

## Validation

Run against Cinch dev (Snowflake, `MOMENTUM_DEV.dbt_development.nexus_resolved_person_identifiers`, 12,519,676 rows):

- Build time: **134.7s** (within the recursive version's typical 23s–630s range; no OOM risk because regular joins can spill).
- `EXCEPT` diff in both directions: **7 rows differ** out of 12.5M (0.00006%). All 7 are short-valued identifiers (`email=p`, `email=jgar4846`, `phone=512982`, etc.) — exactly the substring-collision profile. Verified each is now correctly merged into its true connected component (e.g., `phone=512982` was stranded on its own person_id; under the new macro it joins the 62-member component the rest of its identifiers already shared).
- Schema tests pass: `not_null`/`unique` on `person_identifier_id`, `not_null` on `person_id`.

## Test plan

- [x] `dbt run --select nexus_resolved_person_identifiers --target dev` builds successfully
- [x] `dbt test --select nexus_resolved_person_identifiers --target dev` passes
- [x] `EXCEPT` diff against pre-change baseline: all differences explained by substring-collision bug fix
- [ ] Reviewer: validate on a BigQuery profile (Slide-rule-tech or Austin-Wealth dev) — same `EXCEPT` diff pattern
- [ ] Consumer bump: cinch `packages.yml` revision pointed at the new tag once merged

## Notes

- Snowflake and BigQuery macros now have identical bodies. Collapsing to a single `default__resolve_identifiers` is the obvious follow-up — deferred to keep this PR minimal.
- Version bumped to `0.2.1` in `dbt_project.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)