### PR TITLE
fix(identity-resolution): exclude noise-filter orphans from singletons

### DIFF
--- a/macros/entity-resolution/bigquery__resolve_identifiers.sql
+++ b/macros/entity-resolution/bigquery__resolve_identifiers.sql
@@ -14,15 +14,58 @@
 -- `WITH RECURSIVE` (must be top-level of `WITH`, no UNION ALL with
 -- non-recursive CTEs, no upstream-CTE references in the recursive body).
 
-with depth_0 as (
+with
+-- See snowflake__resolve_identifiers for the rationale on filtered-orphan
+-- exclusion. Same logic applied here for BigQuery parity.
+identifiers_with_surviving_edges as (
+    select distinct entity_type_a as entity_type, identifier_type_a as identifier_type, identifier_value_a as identifier_value
+    from {{ ref(edges_table) }}
+    union distinct
+    select distinct entity_type_b as entity_type, identifier_type_b as identifier_type, identifier_value_b as identifier_value
+    from {{ ref(edges_table) }}
+),
+
+events_with_survivors as (
+    select distinct ei.edge_id
+    from {{ ref(identifiers_table) }} ei
+    inner join identifiers_with_surviving_edges s
+      on s.entity_type = ei.entity_type
+      and s.identifier_type = ei.identifier_type
+      and s.identifier_value = ei.identifier_value
+    where ei.entity_type = '{{ entity_type }}'
+),
+
+filtered_orphan_identifiers as (
+    -- Identifiers with no surviving edges that co-occurred in some event with
+    -- another identifier that DID survive the noise filter. Excluded from
+    -- depth_0 to avoid spurious singleton entities.
+    select distinct ei.identifier_type, ei.identifier_value
+    from {{ ref(identifiers_table) }} ei
+    inner join events_with_survivors ews
+      on ei.edge_id = ews.edge_id
+    left join identifiers_with_surviving_edges s
+      on s.entity_type = ei.entity_type
+      and s.identifier_type = ei.identifier_type
+      and s.identifier_value = ei.identifier_value
+    where ei.entity_type = '{{ entity_type }}'
+      and s.identifier_value is null
+),
+
+depth_0 as (
     -- Base case: every identifier starts as its own component.
+    -- Excludes filtered orphans (see above).
     select distinct
       identifier_type  as component_identifier_type,
       identifier_value as component_identifier_value,
       identifier_type,
       identifier_value
-    from {{ ref(identifiers_table) }}
+    from {{ ref(identifiers_table) }} ei
     where entity_type = '{{ entity_type }}'
+      and not exists (
+        select 1 from filtered_orphan_identifiers fo
+        where fo.identifier_type = ei.identifier_type
+          and fo.identifier_value = ei.identifier_value
+      )
 )
 {% for level in range(1, max_recursion + 1) %}
 ,

--- a/macros/entity-resolution/snowflake__resolve_identifiers.sql
+++ b/macros/entity-resolution/snowflake__resolve_identifiers.sql
@@ -13,15 +13,81 @@
 -- limits (error 100298) and BigQuery's structural restrictions on
 -- `WITH RECURSIVE` (must be top-level, no UNION ALL with non-recursive CTEs).
 
-with depth_0 as (
+with
+-- Identifiers that co-occurred with other identifiers in some event but had
+-- ALL their potential edges dropped by create_identifier_edges' noise filter
+-- (e.g., a phone shared across hundreds of submissions). Without this step
+-- each such identifier would survive depth_0 as its own singleton component
+-- and turn into a standalone entity -- so a single event whose identifiers
+-- include any of these orphans would resolve to multiple entities, one per
+-- orphan, even though intra-event identifiers belong to one entity by
+-- definition. We drop them from the base set; the non-orphan identifiers in
+-- the same event still merge normally via their surviving edges.
+identifiers_with_surviving_edges as (
+    -- Identifiers that retained at least one edge after the noise filter,
+    -- in either direction.
+    select distinct entity_type_a as entity_type, identifier_type_a as identifier_type, identifier_value_a as identifier_value
+    from {{ ref(edges_table) }}
+    union
+    select distinct entity_type_b as entity_type, identifier_type_b as identifier_type, identifier_value_b as identifier_value
+    from {{ ref(edges_table) }}
+),
+
+events_with_survivors as (
+    -- edge_ids (events) containing at least one identifier that has surviving
+    -- edges. An identifier dropped to a singleton inside such an event is
+    -- almost certainly a noise-filter casualty rather than a legitimate
+    -- isolated participant.
+    select distinct ei.edge_id
+    from {{ ref(identifiers_table) }} ei
+    inner join identifiers_with_surviving_edges s
+      on s.entity_type = ei.entity_type
+      and s.identifier_type = ei.identifier_type
+      and s.identifier_value = ei.identifier_value
+    where ei.entity_type = '{{ entity_type }}'
+),
+
+filtered_orphan_identifiers as (
+    -- "Filtered orphans": identifiers with no surviving edges that co-occurred
+    -- in some event with another identifier that DID survive. Without this
+    -- exclusion they would each become their own singleton component and
+    -- emit a spurious entity per event they appear in -- so a single event
+    -- whose identifiers include any of these orphans would resolve to
+    -- multiple entities, one per orphan, even though intra-event identifiers
+    -- belong to one entity by definition. The non-orphan identifiers in the
+    -- same event still merge normally via their surviving edges.
+    --
+    -- Note the "another survived in the same event" condition: a truly
+    -- isolated single-identifier event (no co-occurring survivors) keeps its
+    -- sole identifier as a legitimate singleton entity.
+    select distinct ei.identifier_type, ei.identifier_value
+    from {{ ref(identifiers_table) }} ei
+    inner join events_with_survivors ews
+      on ei.edge_id = ews.edge_id
+    left join identifiers_with_surviving_edges s
+      on s.entity_type = ei.entity_type
+      and s.identifier_type = ei.identifier_type
+      and s.identifier_value = ei.identifier_value
+    where ei.entity_type = '{{ entity_type }}'
+      and s.identifier_value is null
+),
+
+depth_0 as (
     -- Base case: every identifier starts as its own component.
+    -- Excludes filtered orphans (see above) so they don't surface as
+    -- their own standalone entities.
     select distinct
       identifier_type  as component_identifier_type,
       identifier_value as component_identifier_value,
       identifier_type,
       identifier_value
-    from {{ ref(identifiers_table) }}
+    from {{ ref(identifiers_table) }} ei
     where entity_type = '{{ entity_type }}'
+      and not exists (
+        select 1 from filtered_orphan_identifiers fo
+        where fo.identifier_type = ei.identifier_type
+          and fo.identifier_value = ei.identifier_value
+      )
 )
 {% for level in range(1, max_recursion + 1) %}
 ,


### PR DESCRIPTION
## Summary

`create_identifier_edges` drops edges where either side's global degree exceeds the configured noise threshold. That correctly prevents a high-degree identifier — a placeholder email like `noreply@cinchhs.com`, a shared call-center phone, a kiosk GA4 cookie — from acting as a bridge that incorrectly merges unrelated persons.

But the same drop also destroys the **within-event clique**. When a single event has multiple noisy identifiers alongside clean ones, the clean identifiers still merge with each other while each noisy identifier becomes its own singleton component. The result: one event resolves to multiple entities even though, by construction, all identifiers within the same `edge_id` belong to one entity.

## Fix

Exclude "filtered orphans" from `depth_0` in `resolve_identifiers`:

- An identifier is a **filtered orphan** if it has no surviving edges *and* it co-occurred in some event with another identifier that *did* survive the filter.
- A truly isolated single-identifier event has no co-occurring survivors, so its sole identifier is kept as a legitimate singleton entity.

Cross-event safety is preserved: noisy identifiers still don't bridge distinct persons, because they still have no edges in the resolution graph. They're now removed entirely from the base set rather than left as disconnected singleton nodes that surface as standalone entities.

Applied to both `snowflake__resolve_identifiers` and `bigquery__resolve_identifiers` for parity.

## Verification (Cinch DTC kafka lead_submitted events, April 2026)

Participants per event:

| Participants | Before | After |
|---:|---:|---:|
| 0 | — | 65 (test data: `NOEMAIL@NOEMAIL.COM`, `test@test.com`, internal QA) |
| 1 | 14,111 (93.2%) | **15,030 (99.4%)** |
| 2 | 201 | 47 |
| 3 | 762 | **0** |
| 4 | 68 | **0** |

Concrete example: event `evt_9c8d23a3eb7b6fba7f2eab33b0f51568` had identifiers `(email, ga4_client_id, phone, ueid)` where the phone had 1,414 global connections and the ueid had 1,413. Before, this resolved to 3 entities (`{email,ga4}`, `{phone}`, `{ueid}`). After, the phone and ueid are excluded as filtered orphans and the event resolves to a single `{email,ga4}` entity.

`nexus_resolved_person_identifiers` ran in 159s on Cinch's dataset (12.3M rows), no perf regression vs prior.

## Test plan

- [ ] CI passes on both snowflake and bigquery adapter test suites
- [ ] Manual verification against a dataset with known noisy identifiers (Cinch — completed)
- [ ] Confirm legitimate single-identifier-only events still resolve to their entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)