### PR TITLE
feat: cross-adapter support for DuckDB targets

### DIFF
--- a/macros/cross-adapter/convert_timezone.sql
+++ b/macros/cross-adapter/convert_timezone.sql
@@ -1,0 +1,49 @@
+{# Cross-adapter wrapper for the timezone conversion sprinkled
+   throughout cinch's models. Snowflake's `convert_timezone(...)` has
+   no DuckDB equivalent function — DuckDB uses the SQL-standard
+   `AT TIME ZONE 'x' AT TIME ZONE 'y'` form. This macro renders the
+   right SQL for the active target so the model SQL stays portable.
+
+   Accepts both Snowflake signatures:
+
+   - 2-arg: nexus_convert_timezone('UTC', col) — interpret col in the
+     session/server timezone and convert to target_tz.
+   - 3-arg: nexus_convert_timezone('America/New_York', 'UTC', col) —
+     interpret col in source_tz and convert to target_tz.
+
+   `column` is passed as a string and rendered raw into the SQL,
+   so it can be any expression: a bare col, a cast, a function call.
+#}
+{% macro convert_timezone(arg1, arg2, arg3=none) %}
+{%- if arg3 is none -%}
+  {%- set source_tz = none -%}
+  {%- set target_tz = arg1 -%}
+  {%- set column = arg2 -%}
+{%- else -%}
+  {%- set source_tz = arg1 -%}
+  {%- set target_tz = arg2 -%}
+  {%- set column = arg3 -%}
+{%- endif -%}
+{%- if target.type == 'duckdb' -%}
+  {#- DuckDB: AT TIME ZONE returns TIMESTAMPTZ; re-cast back to
+      TIMESTAMP so the result type matches Snowflake's TIMESTAMP_NTZ
+      default (which is what most cinch downstream models expect). -#}
+  {%- if source_tz is none -%}
+    {#- 2-arg form: assume col is already in UTC (cinch's session
+        TZ on Snowflake is UTC), so the conversion is mostly a
+        type assertion. Cast to timestamp and re-anchor at the
+        target tz. -#}
+    cast(cast({{ column }} as timestamp) at time zone 'UTC' at time zone '{{ target_tz }}' as timestamp)
+  {%- else -%}
+    cast(cast({{ column }} as timestamp) at time zone '{{ source_tz }}' at time zone '{{ target_tz }}' as timestamp)
+  {%- endif -%}
+{%- else -%}
+  {#- Snowflake (and other adapters): emit the original
+      convert_timezone() call shape verbatim. -#}
+  {%- if source_tz is none -%}
+    convert_timezone('{{ target_tz }}', {{ column }})
+  {%- else -%}
+    convert_timezone('{{ source_tz }}', '{{ target_tz }}', {{ column }})
+  {%- endif -%}
+{%- endif -%}
+{% endmacro %}

--- a/macros/cross-adapter/dedupe.sql
+++ b/macros/cross-adapter/dedupe.sql
@@ -1,0 +1,43 @@
+{# Cross-adapter dedup-by-key macro.
+
+    Replaces the pattern:
+        select <cols> from <source>
+        qualify row_number() over (partition by <pkey> order by <tiebreak>) = 1
+
+    With a single macro call:
+        {{ nexus_dedupe('<source>', '<pkey>', '<tiebreak>', cols='*') }}
+
+    Why this exists: DuckDB has a query-planner bug where QUALIFY inside a
+    CTAS interacts poorly with try_strptime + many-column SELECTs,
+    producing spurious "invalid timestamp field format" errors. The
+    subquery + WHERE __rn = 1 form is semantically identical, portable
+    across adapters, and dodges the bug.
+
+    On Snowflake we still emit the QUALIFY form for compiled-SQL
+    readability. On DuckDB (and as the safe default) we emit the
+    subquery form.
+
+    Args:
+      source: CTE name or {{ ref('...') }} expression (string)
+      partition_by: comma-separated column list (string)
+      order_by: comma-separated order clause (string, e.g.
+                'etl_load_dt desc nulls last')
+      cols: column list for the outer select (defaults to '*')
+#}
+{% macro dedupe(source, partition_by, order_by, cols='*') %}
+{%- if target.type == 'snowflake' -%}
+select {{ cols }} from {{ source }}
+qualify row_number() over (partition by {{ partition_by }} order by {{ order_by }}) = 1
+{%- else -%}
+select
+  {%- if cols == '*' %} * exclude(__nexus_rn)
+  {%- else %} {{ cols }}
+  {%- endif %}
+from (
+    select *,
+      row_number() over (partition by {{ partition_by }} order by {{ order_by }}) as __nexus_rn
+    from {{ source }}
+)
+where __nexus_rn = 1
+{%- endif -%}
+{% endmacro %}

--- a/macros/cross-adapter/install_duckdb_compat.sql
+++ b/macros/cross-adapter/install_duckdb_compat.sql
@@ -1,0 +1,50 @@
+{# Snowflake-compat shims for DuckDB targets.
+
+    Returns a single SQL string (multi-statement is fine — DuckDB
+    accepts it) that:
+
+      1. Aliases Snowflake-specific type names (TIMESTAMP_NTZ, etc.)
+         to native DuckDB types so cast(... as timestamp_ntz) works.
+      2. Defines DuckDB MACROs that mimic Snowflake scalar functions
+         lacking native DuckDB equivalents (iff, regexp_substr,
+         regexp_like, try_parse_json, try_to_double, try_to_number,
+         array_construct, array_contains, current_timestamp()).
+      3. Disables DuckDB's expression_rewriter optimizer, which has a
+         bug where try_strptime + windowed dedup + many-column CTAS
+         produces spurious "invalid timestamp format" errors.
+
+    Consumers call this from `on-run-start` in their dbt_project.yml:
+
+        on-run-start:
+          - "{{ nexus.install_duckdb_compat() }}"
+
+    No-op on non-DuckDB targets — returns an empty string.
+#}
+{% macro install_duckdb_compat() %}
+{%- if target.type != 'duckdb' -%}
+{%- else -%}
+-- Snowflake type aliases
+CREATE TYPE IF NOT EXISTS timestamp_ntz AS TIMESTAMP;
+CREATE TYPE IF NOT EXISTS timestamp_tz AS TIMESTAMPTZ;
+CREATE TYPE IF NOT EXISTS variant AS JSON;
+
+-- Snowflake scalar function aliases
+CREATE OR REPLACE MACRO current_timestamp() AS now();
+CREATE OR REPLACE MACRO iff(c, t, f) AS CASE WHEN c THEN t ELSE f END;
+CREATE OR REPLACE MACRO regexp_substr(s, p, pos := 1, occ := 1, mode := 'c', grp := 0) AS
+    CASE WHEN mode = 'e' THEN regexp_extract(s, p, grp)
+         ELSE regexp_extract(s, p) END;
+CREATE OR REPLACE MACRO regexp_like(s, p) AS regexp_matches(s, p);
+CREATE OR REPLACE MACRO try_parse_json(s) AS try_cast(s AS json);
+CREATE OR REPLACE MACRO try_to_double(s) AS try_cast(s AS double);
+CREATE OR REPLACE MACRO try_to_number(s) AS try_cast(s AS decimal(38,0));
+CREATE OR REPLACE MACRO array_construct() AS list_value();
+CREATE OR REPLACE MACRO array_contains(needle, haystack) AS list_contains(haystack, needle);
+
+-- Disable expression_rewriter: bug where try_strptime + windowed dedup
+-- in a many-column CTAS surfaces as "invalid timestamp field format"
+-- against a column unrelated to the cast. Small (likely negligible)
+-- perf cost in dev.
+SET disabled_optimizers='expression_rewriter';
+{%- endif -%}
+{% endmacro %}

--- a/macros/cross-adapter/interval_cast.sql
+++ b/macros/cross-adapter/interval_cast.sql
@@ -1,0 +1,22 @@
+{# Cross-adapter wrapper for casting an HH:MM:SS-style duration string
+   into an INTERVAL type.
+
+   Snowflake: `cast(s as interval hour(9) to second(0))` — with precision
+              spec required for sub-second / over-24-hour durations.
+   DuckDB:    `cast(s as interval)` — no precision spec; auto-parses
+              HH:MM:SS and similar forms.
+
+   Snowflake also has try_cast(s as interval ...). Match that with a
+   `try` flag.
+#}
+{% macro interval_cast(column, try=false) %}
+{%- if target.type == 'duckdb' -%}
+  {%- if try -%}try_cast({{ column }} as interval)
+  {%- else -%}cast({{ column }} as interval)
+  {%- endif -%}
+{%- else -%}
+  {%- if try -%}try_cast({{ column }} as interval hour(9) to second(0))
+  {%- else -%}cast({{ column }} as interval hour(9) to second(0))
+  {%- endif -%}
+{%- endif -%}
+{% endmacro %}

--- a/macros/cross-adapter/json.sql
+++ b/macros/cross-adapter/json.sql
@@ -1,0 +1,118 @@
+{# Cross-adapter JSON parsing.
+
+   Snowflake stores parsed JSON as the `VARIANT` type, navigated with
+   the `:` operator (`col:a:b::TYPE`). DuckDB uses the `JSON` type with
+   `json_extract*` functions and JSONPath strings (`'$.a.b'`). BigQuery
+   has `JSON` type with `JSON_VALUE`/`JSON_QUERY`.
+
+   These macros wrap both layers so model SQL stays adapter-agnostic.
+#}
+
+{# Parse a text column as JSON / VARIANT.
+
+   Usage:
+     select {{ nexus.parse_json('JSON_MESSAGE') }} as payload from ...
+     select {{ nexus.parse_json('JSON_MESSAGE', try=true) }} as payload from ...
+
+   `try=true` returns NULL on parse failure rather than raising; matches
+   Snowflake's `TRY_PARSE_JSON`. Default is non-try (raise on bad JSON).
+#}
+{% macro parse_json(column, try=false) %}
+{%- if target.type == 'snowflake' -%}
+  {%- if try -%}try_parse_json({{ column }}){%- else -%}parse_json({{ column }}){%- endif -%}
+{%- elif target.type == 'duckdb' -%}
+  {%- if try -%}try_cast({{ column }} as json){%- else -%}cast({{ column }} as json){%- endif -%}
+{%- elif target.type == 'bigquery' -%}
+  {%- if try -%}safe.parse_json({{ column }}){%- else -%}parse_json({{ column }}){%- endif -%}
+{%- else -%}
+  {{ exceptions.raise_compiler_error("nexus.parse_json() does not support target.type='" ~ target.type ~ "' yet") }}
+{%- endif -%}
+{% endmacro %}
+
+
+{# Extract a value from a parsed-JSON column at a dotted path, with
+   optional type cast.
+
+   Usage:
+     {{ nexus.json_path('payload', 'analytics_data.pageUrl', 'string') }}
+     {{ nexus.json_path('payload', 'event_time', 'bigint') }}
+     {{ nexus.json_path('payload', 'event_input.contents') }}    -- no type → raw sub-object
+
+   Path is a dotted string: 'a.b.c' navigates payload→a→b→c.
+   Type is one of: string, bigint, int, integer, float, double,
+                   boolean, bool, timestamp, date, json (raw),
+                   or None / omitted for raw VARIANT/JSON.
+
+   Adapter rendering:
+     Snowflake: `{{ column }}:a:b:c::TYPE`
+     DuckDB:    `json_extract*({{ column }}, '$.a.b.c')::TYPE`
+                 (uses json_extract_string for string output, json_extract
+                  otherwise — DuckDB's STRING cast loses quoting)
+     BigQuery:  `JSON_VALUE({{ column }}, '$.a.b.c')` for scalars,
+                 `JSON_QUERY` for raw sub-objects; cast to SQL type.
+#}
+{% macro json_path(column, path, type=none) %}
+{%- set segments = path.split('.') -%}
+{%- if target.type == 'snowflake' -%}
+  {%- set sf_path = ':' ~ (segments | join(':')) -%}
+  {%- set sf_type = nexus._nexus_json_type_to_sf(type) -%}
+  {{ column }}{{ sf_path }}{%- if sf_type %}::{{ sf_type }}{%- endif -%}
+{%- elif target.type == 'duckdb' -%}
+  {%- set duck_path = "'$." ~ (segments | join('.')) ~ "'" -%}
+  {%- set duck_type = nexus._nexus_json_type_to_duck(type) -%}
+  {%- if type and type|lower in ['string', 'varchar', 'text'] -%}
+    json_extract_string({{ column }}, {{ duck_path }})
+  {%- elif duck_type -%}
+    cast(json_extract({{ column }}, {{ duck_path }}) as {{ duck_type }})
+  {%- else -%}
+    json_extract({{ column }}, {{ duck_path }})
+  {%- endif -%}
+{%- elif target.type == 'bigquery' -%}
+  {%- set bq_path = "'$." ~ (segments | join('.')) ~ "'" -%}
+  {%- if type is none or type|lower == 'json' -%}
+    json_query({{ column }}, {{ bq_path }})
+  {%- elif type|lower in ['string', 'varchar', 'text'] -%}
+    json_value({{ column }}, {{ bq_path }})
+  {%- else -%}
+    cast(json_value({{ column }}, {{ bq_path }}) as {{ nexus._nexus_json_type_to_bq(type) }})
+  {%- endif -%}
+{%- else -%}
+  {{ exceptions.raise_compiler_error("nexus.json_path() does not support target.type='" ~ target.type ~ "' yet") }}
+{%- endif -%}
+{% endmacro %}
+
+
+{# Internal: normalize the type arg into per-adapter SQL type names.
+   Returns empty string when the type should be omitted (raw access). #}
+{% macro _nexus_json_type_to_sf(type) -%}
+{%- if type is none or type|lower == 'json' -%}{%- elif type|lower in ['string','varchar','text'] -%}string
+{%- elif type|lower in ['int','integer'] -%}integer
+{%- elif type|lower in ['bigint','long'] -%}bigint
+{%- elif type|lower in ['float','double','number'] -%}{{ type|lower }}
+{%- elif type|lower in ['boolean','bool'] -%}boolean
+{%- elif type|lower in ['timestamp','timestamp_ntz','timestamp_tz','date'] -%}{{ type|lower }}
+{%- else -%}{{ type }}{%- endif -%}
+{%- endmacro %}
+
+{% macro _nexus_json_type_to_duck(type) -%}
+{%- if type is none or type|lower == 'json' -%}{%- elif type|lower in ['string','varchar','text'] -%}varchar
+{%- elif type|lower in ['int','integer'] -%}integer
+{%- elif type|lower in ['bigint','long'] -%}bigint
+{%- elif type|lower in ['float','double'] -%}double
+{%- elif type|lower == 'number' -%}decimal(38,0)
+{%- elif type|lower in ['boolean','bool'] -%}boolean
+{%- elif type|lower in ['timestamp','timestamp_ntz'] -%}timestamp
+{%- elif type|lower == 'timestamp_tz' -%}timestamptz
+{%- elif type|lower == 'date' -%}date
+{%- else -%}{{ type }}{%- endif -%}
+{%- endmacro %}
+
+{% macro _nexus_json_type_to_bq(type) -%}
+{%- if type|lower in ['string','varchar','text'] -%}string
+{%- elif type|lower in ['int','integer','bigint','long'] -%}int64
+{%- elif type|lower in ['float','double','number'] -%}float64
+{%- elif type|lower in ['boolean','bool'] -%}bool
+{%- elif type|lower in ['timestamp','timestamp_ntz','timestamp_tz'] -%}timestamp
+{%- elif type|lower == 'date' -%}date
+{%- else -%}{{ type }}{%- endif -%}
+{%- endmacro %}

--- a/macros/cross-adapter/try_to_timestamp.sql
+++ b/macros/cross-adapter/try_to_timestamp.sql
@@ -1,0 +1,123 @@
+{# Cross-adapter wrapper for try_to_timestamp / try_to_timestamp_ntz.
+
+    Snowflake forms used in cinch:
+        try_to_timestamp(col)
+        try_to_timestamp(col, 'MM/DD/YYYY HH24:MI:SS')
+        try_to_timestamp(col, 'MM/DD/YYYY HH12:MI:SS AM')
+        try_to_timestamp_ntz(col)
+
+    DuckDB has no try_to_timestamp; closest equivalents:
+        try_cast(col as timestamp)       — no format string
+        try_strptime(col, '<strptime format>')  — needs translation
+
+    Snowflake format → strptime translation:
+        YYYY → %Y     MM → %m     DD → %d
+        HH24 → %H     HH12 → %I   MI → %M     SS → %S
+        AM   → %p
+
+    Snowflake's behavior on parse failure: returns NULL.
+    DuckDB's try_strptime / try_cast: same.
+#}
+{% macro try_to_timestamp(column, snowflake_format=none) %}
+{%- if target.type == 'duckdb' -%}
+  {%- if snowflake_format is none -%}
+    try_cast({{ column }} as timestamp)
+  {%- else -%}
+    {%- set fmt = snowflake_format -%}
+    {%- set fmt = fmt | replace('YYYY', '%Y') -%}
+    {%- set fmt = fmt | replace('HH24', '%H') -%}
+    {%- set fmt = fmt | replace('HH12', '%I') -%}
+    {%- set fmt = fmt | replace('MM',   '%m') -%}
+    {%- set fmt = fmt | replace('DD',   '%d') -%}
+    {%- set fmt = fmt | replace('MI',   '%M') -%}
+    {%- set fmt = fmt | replace('SS',   '%S') -%}
+    {%- set fmt = fmt | replace('AM',   '%p') -%}
+    try_strptime({{ column }}, '{{ fmt }}')
+  {%- endif -%}
+{%- else -%}
+  {%- if snowflake_format is none -%}
+    try_to_timestamp({{ column }})
+  {%- else -%}
+    try_to_timestamp({{ column }}, '{{ snowflake_format }}')
+  {%- endif -%}
+{%- endif -%}
+{% endmacro %}
+
+
+{# try_to_timestamp_ntz: same as try_to_timestamp on DuckDB
+    (it has no _ntz distinction). On Snowflake, emit the _ntz variant
+    so the original NTZ-typed result is preserved. #}
+{% macro try_to_timestamp_ntz(column, snowflake_format=none) %}
+{%- if target.type == 'duckdb' -%}
+  {{ nexus.try_to_timestamp(column, snowflake_format) }}
+{%- else -%}
+  {%- if snowflake_format is none -%}
+    try_to_timestamp_ntz({{ column }})
+  {%- else -%}
+    try_to_timestamp_ntz({{ column }}, '{{ snowflake_format }}')
+  {%- endif -%}
+{%- endif -%}
+{% endmacro %}
+
+
+{# to_timestamp / to_timestamp_ntz: non-try variants. Snowflake raises on
+    bad input, DuckDB cast raises too. Functionally equivalent. #}
+{% macro to_timestamp(column, snowflake_format=none) %}
+{%- if target.type == 'duckdb' -%}
+  {%- if snowflake_format is none -%}
+    cast({{ column }} as timestamp)
+  {%- else -%}
+    {%- set fmt = snowflake_format -%}
+    {%- set fmt = fmt | replace('YYYY', '%Y') -%}
+    {%- set fmt = fmt | replace('HH24', '%H') -%}
+    {%- set fmt = fmt | replace('HH12', '%I') -%}
+    {%- set fmt = fmt | replace('MM',   '%m') -%}
+    {%- set fmt = fmt | replace('DD',   '%d') -%}
+    {%- set fmt = fmt | replace('MI',   '%M') -%}
+    {%- set fmt = fmt | replace('SS',   '%S') -%}
+    {%- set fmt = fmt | replace('AM',   '%p') -%}
+    strptime({{ column }}, '{{ fmt }}')
+  {%- endif -%}
+{%- else -%}
+  {%- if snowflake_format is none -%}
+    to_timestamp({{ column }})
+  {%- else -%}
+    to_timestamp({{ column }}, '{{ snowflake_format }}')
+  {%- endif -%}
+{%- endif -%}
+{% endmacro %}
+
+
+{# to_timestamp_ntz: Snowflake's polymorphic to_timestamp_ntz auto-
+    detects input type (string → parse, bigint → epoch micros). DuckDB
+    has separate functions: cast(s as timestamp) for strings,
+    make_timestamp(bigint) for micros. We can't auto-dispatch in a
+    macro since input type isn't known at compile time — so callers
+    pick the appropriate variant explicitly.
+
+    nexus_to_timestamp_ntz(col)            — string / generic case
+    nexus_to_timestamp_ntz_from_micros(col) — bigint epoch microseconds
+#}
+{% macro to_timestamp_ntz(column) %}
+{%- if target.type == 'duckdb' -%}
+  cast({{ column }} as timestamp)
+{%- else -%}
+  to_timestamp_ntz({{ column }})
+{%- endif -%}
+{% endmacro %}
+
+{% macro to_timestamp_ntz_from_micros(column) %}
+{%- if target.type == 'duckdb' -%}
+  make_timestamp({{ column }})
+{%- else -%}
+  to_timestamp_ntz({{ column }})
+{%- endif -%}
+{% endmacro %}
+
+{% macro to_timestamp_ntz_from_seconds(column) %}
+{%- if target.type == 'duckdb' -%}
+  cast(to_timestamp({{ column }}) as timestamp)
+{%- else -%}
+  to_timestamp_ntz({{ column }})
+{%- endif -%}
+{% endmacro %}

--- a/macros/entity-resolution/duckdb__resolve_identifiers.sql
+++ b/macros/entity-resolution/duckdb__resolve_identifiers.sql
@@ -1,0 +1,110 @@
+{# DuckDB implementation of resolve_identifiers.
+
+    Identical Jinja-unrolled CTE shape to snowflake__resolve_identifiers —
+    the SQL uses only standard window functions, UNION (dedup), and CTEs,
+    all of which DuckDB supports with the same semantics as Snowflake.
+
+    Without this, projects using dbt-nexus on a DuckDB target fail to
+    parse with "No macro named 'resolve_identifiers' found within
+    namespace: 'dbt_nexus'", since dispatch only knows about snowflake__
+    and bigquery__ variants.
+#}
+{% macro duckdb__resolve_identifiers(entity_type, identifiers_table, edges_table, max_recursion=10) %}
+
+with depth_0 as (
+    select distinct
+      identifier_type  as component_identifier_type,
+      identifier_value as component_identifier_value,
+      identifier_type,
+      identifier_value
+    from {{ ref(identifiers_table) }}
+    where entity_type = '{{ entity_type }}'
+)
+{% for level in range(1, max_recursion + 1) %}
+,
+depth_{{ level }} as (
+    select * from depth_{{ level - 1 }}
+    union
+    select
+      d.component_identifier_type,
+      d.component_identifier_value,
+      e.identifier_type_b  as identifier_type,
+      e.identifier_value_b as identifier_value
+    from depth_{{ level - 1 }} d
+    join {{ ref(edges_table) }} e
+      on d.identifier_type  = e.identifier_type_a
+     and d.identifier_value = e.identifier_value_a
+     and e.entity_type_a = '{{ entity_type }}'
+     and e.entity_type_b = '{{ entity_type }}'
+)
+{% endfor %}
+,
+
+component_values as (
+  select
+    identifier_type,
+    identifier_value,
+    first_value(component_identifier_type) over(
+      partition by identifier_type, identifier_value
+      order by component_identifier_type, component_identifier_value
+    ) as first_component_type,
+    first_value(component_identifier_value) over(
+      partition by identifier_type, identifier_value
+      order by component_identifier_type, component_identifier_value
+    ) as first_component_value
+  from depth_{{ max_recursion }}
+),
+
+component_mapping as (
+  select
+    identifier_type,
+    identifier_value,
+    {{ create_nexus_id(entity_type, ['first_component_type', 'first_component_value']) }} as component_id
+  from component_values
+  group by identifier_type, identifier_value, first_component_type, first_component_value
+),
+
+entity_identifiers as (
+  select * from {{ ref(identifiers_table) }}
+  where entity_type = '{{ entity_type }}'
+),
+
+resolved_identifiers as (
+  select
+    u.edge_id,
+    u.event_id,
+    u.identifier_type,
+    u.identifier_value,
+    c.component_id as {{ entity_type }}_id
+  from entity_identifiers u
+  join component_mapping c
+    on u.identifier_type = c.identifier_type
+    and u.identifier_value = c.identifier_value
+),
+
+deduplicated_identifiers as (
+  select
+    identifier_type,
+    identifier_value,
+    {{ entity_type }}_id,
+    event_id,
+    edge_id,
+    row_number() over(
+      partition by identifier_type, identifier_value
+      order by edge_id
+    ) as row_num
+  from resolved_identifiers
+)
+
+select
+  {{ create_nexus_id(entity_type ~ '_identifier', [entity_type ~ '_id', 'identifier_type', 'identifier_value']) }} as {{ entity_type }}_identifier_id,
+  {{ entity_type }}_id,
+  event_id,
+  identifier_type,
+  identifier_value,
+  false as realtime_processed,
+  true as existing_{{ entity_type }}
+from deduplicated_identifiers
+where row_num = 1
+
+{% endmacro %}


### PR DESCRIPTION
## Summary

Adds first-class DuckDB adapter support to dbt-nexus alongside the existing Snowflake and BigQuery paths. Useful for local-dev workflows where a client's warehouse data is extracted to Parquet and queried through DuckDB — same models, different target.

## What's new

**Adapter dispatch:**
- \`macros/entity-resolution/duckdb__resolve_identifiers.sql\` — same Jinja-unrolled CTE shape as the snowflake__ variant. The SQL uses only standard window functions, UNION dedup, and CTEs (all DuckDB-supported with identical semantics).

**New \`macros/cross-adapter/\` library** — all callable as \`{{ nexus.<name>(...) }}\`:

| Macro | Purpose |
|---|---|
| \`convert_timezone(...)\` | Snowflake's 2-arg / 3-arg \`convert_timezone\` → DuckDB \`AT TIME ZONE\` |
| \`try_to_timestamp\`, \`to_timestamp\`, \`to_timestamp_ntz\`, \`to_timestamp_ntz_from_micros\`, \`to_timestamp_ntz_from_seconds\` | Cross-adapter timestamp parsing, with Snowflake-format-string → strptime translation |
| \`interval_cast(col, try=false)\` | Snowflake \`hour(9) to second(0)\` precision → DuckDB bare \`interval\` |
| \`dedupe(source, partition_by, order_by, cols='*')\` | Emits QUALIFY on Snowflake, subquery+WHERE on DuckDB (dodges a known DuckDB CTAS+QUALIFY+try_strptime bug) |
| \`parse_json(col, try=false)\` | Cross-adapter JSON parse (Snowflake PARSE_JSON / DuckDB cast as JSON / BigQuery PARSE_JSON) |
| \`json_path(col, 'a.b.c', type)\` | Variant-path access (Snowflake \`col:a:b:c::TYPE\` / DuckDB \`json_extract*(col, '\$.a.b.c')\` / BigQuery JSON_VALUE/JSON_QUERY) |
| \`install_duckdb_compat()\` | Single \`on-run-start\` entry: type aliases, scalar function MACROs (iff, regexp_substr/like, try_parse_json, try_to_double, try_to_number, array_construct, array_contains, current_timestamp), and the \`SET disabled_optimizers='expression_rewriter'\` planner workaround |

## Why

Verified end-to-end on the cinch \`dw-ga4\` project: \`dbt run --target duck --select +nexus_events\` builds **72/85 models** against local Parquet, with no changes to compiled Snowflake SQL. The 13 remaining failures are extract-side issues (missing extracts, parquet schema variance), not macro-related.

Companion changes in the cinch project use these macros from packages.yml as \`- local: ../../../dbt-nexus\` during development; once this PR ships in a tagged release, they'll pin to the version.

## Usage

\`\`\`yaml
# packages.yml
packages:
  - git: https://github.com/slide-rule-tech/dbt-nexus
    revision: <tag>

# dbt_project.yml
on-run-start:
  - \"{{ nexus.install_duckdb_compat() }}\"
\`\`\`

\`\`\`sql
-- models
select
  {{ nexus.convert_timezone('America/New_York', 'UTC', 'created_at') }} as created_at_utc,
  {{ nexus.json_path('payload', 'analytics_data.campaign', 'string') }} as campaign
from {{ source('kafka', 'PARTNER_WEB_LEAD') }}
\`\`\`

## Test plan

- [x] \`dbt parse --target snowflake\` clean — no regression (macros only dispatch to snowflake on snowflake target)
- [x] \`dbt parse --target duckdb\` clean
- [x] \`dbt run --target duck\` builds 72/85 models in cinch's project
- [x] \`duckdb__resolve_identifiers\` produces same output as snowflake__ for matched inputs
- [ ] BigQuery branch of json macros — written but not exercised in CI

## Notes

- \`dedupe\` workaround is forward-compatible: when DuckDB fixes the planner bug it works around, the macro can switch to QUALIFY on DuckDB too (or just stay on the subquery form for consistency).
- \`install_duckdb_compat()\` is a no-op on non-DuckDB targets — safe to add to \`on-run-start\` unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)