### PR TITLE
feat(cross-adapter): try_to_date, regexp_extract_group, json_path[N], UTC session pin

### DIFF
--- a/macros/cross-adapter/install_duckdb_compat.sql
+++ b/macros/cross-adapter/install_duckdb_compat.sql
@@ -46,5 +46,16 @@ CREATE OR REPLACE MACRO array_contains(needle, haystack) AS list_contains(haysta
 -- against a column unrelated to the cast. Small (likely negligible)
 -- perf cost in dev.
 SET disabled_optimizers='expression_rewriter';
+
+-- Match Snowflake's UTC session timezone. Without this, DuckDB's
+-- session TZ defaults to the host's local TZ, and the SQL idiom
+--   cast(<timestamptz expr> as timestamp)
+-- (used by nexus.convert_timezone among other places) extracts the
+-- wall-clock value in local TZ rather than UTC. The result is
+-- timestamps offset by the local-UTC delta — visible as
+-- boundary events shifting between calendar days/months relative
+-- to Snowflake builds. Pinning the session to UTC aligns duck
+-- with Snowflake's session_parameters.TIMEZONE='UTC'.
+SET TimeZone='UTC';
 {%- endif -%}
 {% endmacro %}

--- a/macros/cross-adapter/json.sql
+++ b/macros/cross-adapter/json.sql
@@ -30,45 +30,63 @@
 {% endmacro %}
 
 
-{# Extract a value from a parsed-JSON column at a dotted path, with
-   optional type cast.
+{# Extract a value from a parsed-JSON column at a path, with optional
+   type cast.
 
    Usage:
      {{ nexus.json_path('payload', 'analytics_data.pageUrl', 'string') }}
      {{ nexus.json_path('payload', 'event_time', 'bigint') }}
-     {{ nexus.json_path('payload', 'event_input.contents') }}    -- no type → raw sub-object
+     {{ nexus.json_path('payload', 'event_input.contents') }}     -- no type → raw sub-object
+     {{ nexus.json_path('items', '[0].item_name', 'string') }}    -- array index then key
+     {{ nexus.json_path('a', 'b[2].c[1].d', 'number') }}          -- nested arrays
 
-   Path is a dotted string: 'a.b.c' navigates payload→a→b→c.
+   Path is a string of dotted keys with optional `[N]` array indexers.
    Type is one of: string, bigint, int, integer, float, double,
                    boolean, bool, timestamp, date, json (raw),
                    or None / omitted for raw VARIANT/JSON.
 
    Adapter rendering:
-     Snowflake: `{{ column }}:a:b:c::TYPE`
-     DuckDB:    `json_extract*({{ column }}, '$.a.b.c')::TYPE`
+     Snowflake: `{{ column }}:a:b:c::TYPE` (or `[0]:name`, etc.)
+     DuckDB:    `json_extract*({{ column }}, '$.a.b.c')::TYPE` (JSONPath)
                  (uses json_extract_string for string output, json_extract
                   otherwise — DuckDB's STRING cast loses quoting)
      BigQuery:  `JSON_VALUE({{ column }}, '$.a.b.c')` for scalars,
                  `JSON_QUERY` for raw sub-objects; cast to SQL type.
 #}
 {% macro json_path(column, path, type=none) %}
-{%- set segments = path.split('.') -%}
+{%- set tokens = nexus._nexus_split_json_path(path) -%}
 {%- if target.type == 'snowflake' -%}
-  {%- set sf_path = ':' ~ (segments | join(':')) -%}
+  {%- set sf_path -%}
+    {%- for tok in tokens -%}
+      {%- if tok.kind == 'index' -%}[{{ tok.value }}]{%- else -%}:{{ tok.value }}{%- endif -%}
+    {%- endfor -%}
+  {%- endset -%}
   {%- set sf_type = nexus._nexus_json_type_to_sf(type) -%}
   {{ column }}{{ sf_path }}{%- if sf_type %}::{{ sf_type }}{%- endif -%}
 {%- elif target.type == 'duckdb' -%}
-  {%- set duck_path = "'$." ~ (segments | join('.')) ~ "'" -%}
+  {%- set duck_path -%}
+    '${%- for tok in tokens -%}
+      {%- if tok.kind == 'index' -%}[{{ tok.value }}]{%- else -%}.{{ tok.value }}{%- endif -%}
+    {%- endfor -%}'
+  {%- endset -%}
   {%- set duck_type = nexus._nexus_json_type_to_duck(type) -%}
   {%- if type and type|lower in ['string', 'varchar', 'text'] -%}
     json_extract_string({{ column }}, {{ duck_path }})
   {%- elif duck_type -%}
-    cast(json_extract({{ column }}, {{ duck_path }}) as {{ duck_type }})
+    {# try_cast (not cast) matches Snowflake VARIANT::TYPE semantics —
+       on Snowflake, casting a variant to a non-matching type returns
+       NULL silently. DuckDB's plain cast(json_extract(...) as DECIMAL)
+       raises on non-numeric values; try_cast preserves NULL behavior. #}
+    try_cast(json_extract({{ column }}, {{ duck_path }}) as {{ duck_type }})
   {%- else -%}
     json_extract({{ column }}, {{ duck_path }})
   {%- endif -%}
 {%- elif target.type == 'bigquery' -%}
-  {%- set bq_path = "'$." ~ (segments | join('.')) ~ "'" -%}
+  {%- set bq_path -%}
+    '${%- for tok in tokens -%}
+      {%- if tok.kind == 'index' -%}[{{ tok.value }}]{%- else -%}.{{ tok.value }}{%- endif -%}
+    {%- endfor -%}'
+  {%- endset -%}
   {%- if type is none or type|lower == 'json' -%}
     json_query({{ column }}, {{ bq_path }})
   {%- elif type|lower in ['string', 'varchar', 'text'] -%}
@@ -80,6 +98,31 @@
   {{ exceptions.raise_compiler_error("nexus.json_path() does not support target.type='" ~ target.type ~ "' yet") }}
 {%- endif -%}
 {% endmacro %}
+
+
+{# Internal: tokenize a json path string into a list of {kind, value}
+   tokens. kind is 'key' or 'index'. Supports paths like "a.b",
+   "items[0].name", "[0].x", "a[1][2].b". #}
+{% macro _nexus_split_json_path(path) -%}
+  {%- set out = [] -%}
+  {%- set buf = namespace(v='') -%}
+  {%- for ch in path -%}
+    {%- if ch == '.' -%}
+      {%- if buf.v -%}{%- do out.append({'kind':'key','value':buf.v}) -%}{%- endif -%}
+      {%- set buf.v = '' -%}
+    {%- elif ch == '[' -%}
+      {%- if buf.v -%}{%- do out.append({'kind':'key','value':buf.v}) -%}{%- endif -%}
+      {%- set buf.v = '' -%}
+    {%- elif ch == ']' -%}
+      {%- if buf.v -%}{%- do out.append({'kind':'index','value':buf.v}) -%}{%- endif -%}
+      {%- set buf.v = '' -%}
+    {%- else -%}
+      {%- set buf.v = buf.v ~ ch -%}
+    {%- endif -%}
+  {%- endfor -%}
+  {%- if buf.v -%}{%- do out.append({'kind':'key','value':buf.v}) -%}{%- endif -%}
+  {{- return(out) -}}
+{%- endmacro %}
 
 
 {# Internal: normalize the type arg into per-adapter SQL type names.

--- a/macros/cross-adapter/regexp.sql
+++ b/macros/cross-adapter/regexp.sql
@@ -1,0 +1,37 @@
+{# Cross-adapter regex helpers. #}
+
+{# Extract a single capture group from a regex match.
+
+    Snowflake: REGEXP_SUBSTR(str, pattern, position, occurrence, parameters, group_num)
+        e.g., REGEXP_SUBSTR(col, 'OPT-(\\d+)', 1, 1, 'e', 1) → capture group 1
+        (NOTE: Snowflake string literals interpret `\\` as `\`, so a
+         regex `\d` requires `'\\d'` in source SQL.)
+
+    DuckDB: regexp_extract(str, pattern, group_idx)
+        e.g., regexp_extract(col, 'OPT-(\d+)', 1) → capture group 1
+        (DuckDB string literals do NOT interpret backslashes — `'\d'`
+         is the 2-char string `\d`, and the regex engine sees `\d`.)
+
+    BigQuery: REGEXP_EXTRACT(str, pattern) returns capture group 1 only;
+        group N not yet implemented here.
+
+    Usage:
+      {{ nexus.regexp_extract_group('col', 'OPT-(\\d+)\\((.*)\\)', 2) }}
+
+    The `pattern` arg should be written with `\\` for each regex
+    backslash (Jinja string-escape rules). The macro auto-doubles
+    backslashes again on Snowflake so the resulting SQL string literal
+    decodes back to a single backslash in the regex.
+#}
+{% macro regexp_extract_group(column, pattern, group_num=1) %}
+{%- if target.type == 'duckdb' -%}
+  regexp_extract({{ column }}, '{{ pattern }}', {{ group_num }})
+{%- elif target.type == 'snowflake' -%}
+  {%- set sf_pattern = pattern | replace('\\', '\\\\') -%}
+  regexp_substr({{ column }}, '{{ sf_pattern }}', 1, 1, 'e', {{ group_num }})
+{%- elif target.type == 'bigquery' -%}
+  regexp_extract({{ column }}, '{{ pattern }}')
+{%- else -%}
+  {{ exceptions.raise_compiler_error("nexus.regexp_extract_group() does not support target.type='" ~ target.type ~ "' yet") }}
+{%- endif -%}
+{% endmacro %}

--- a/macros/cross-adapter/try_to_date.sql
+++ b/macros/cross-adapter/try_to_date.sql
@@ -1,0 +1,57 @@
+{# Cross-adapter wrapper for try_to_date / to_date.
+
+    Snowflake forms used in cinch (and similar warehouses):
+        try_to_date(col)
+        try_to_date(col, 'MM-DD-YYYY')
+        try_to_date(col, 'YYYY-MM-DD')
+
+    DuckDB has no try_to_date. Equivalents:
+        try_cast(col as date)              — no format string
+        try_strptime(col, '<fmt>')::date   — needs Snowflake→strptime translation
+
+    Snowflake format → strptime translation (same rules as try_to_timestamp):
+        YYYY → %Y     MM → %m     DD → %d
+
+    Both adapters return NULL on parse failure for the try_ variants.
+#}
+{% macro try_to_date(column, snowflake_format=none) %}
+{%- if target.type == 'duckdb' -%}
+  {%- if snowflake_format is none -%}
+    try_cast({{ column }} as date)
+  {%- else -%}
+    {%- set fmt = snowflake_format -%}
+    {%- set fmt = fmt | replace('YYYY', '%Y') -%}
+    {%- set fmt = fmt | replace('MM',   '%m') -%}
+    {%- set fmt = fmt | replace('DD',   '%d') -%}
+    try_cast(try_strptime({{ column }}, '{{ fmt }}') as date)
+  {%- endif -%}
+{%- else -%}
+  {%- if snowflake_format is none -%}
+    try_to_date({{ column }})
+  {%- else -%}
+    try_to_date({{ column }}, '{{ snowflake_format }}')
+  {%- endif -%}
+{%- endif -%}
+{% endmacro %}
+
+
+{# Non-try variant: raises on bad input on both Snowflake and DuckDB. #}
+{% macro to_date(column, snowflake_format=none) %}
+{%- if target.type == 'duckdb' -%}
+  {%- if snowflake_format is none -%}
+    cast({{ column }} as date)
+  {%- else -%}
+    {%- set fmt = snowflake_format -%}
+    {%- set fmt = fmt | replace('YYYY', '%Y') -%}
+    {%- set fmt = fmt | replace('MM',   '%m') -%}
+    {%- set fmt = fmt | replace('DD',   '%d') -%}
+    cast(strptime({{ column }}, '{{ fmt }}') as date)
+  {%- endif -%}
+{%- else -%}
+  {%- if snowflake_format is none -%}
+    to_date({{ column }})
+  {%- else -%}
+    to_date({{ column }}, '{{ snowflake_format }}')
+  {%- endif -%}
+{%- endif -%}
+{% endmacro %}


### PR DESCRIPTION
## Summary

Three small cross-adapter additions + one DuckDB session pin that
unblock cinch's GA4 + direct-mail normalized layers on DuckDB without
changing Snowflake behavior.

- **`nexus.try_to_date` / `nexus.to_date`** — analog of the existing
  `try_to_timestamp` family, with Snowflake format-code → strptime
  translation (`MM-DD-YYYY` → `%m-%d-%Y`, etc.). Cinch uses this to
  parse the `DMG_INBOUND_DIRECT_MAIL_TEMP.CL_MAIL_DROP` text field.

- **`nexus.regexp_extract_group(col, pattern, group_num)`** — wraps
  Snowflake's `REGEXP_SUBSTR(..., 1, 1, 'e', N)` 6-arg form (capture
  group `N`) and DuckDB's `regexp_extract(..., N)`. Auto-doubles
  backslashes for Snowflake so the same pattern literal works on
  both adapters' string-literal conventions. Cinch uses this for the
  Optimizely `OPT-(\d+)\((.*)\)-...` extraction in the GA4
  destructured CTE.

- **`nexus.json_path` extensions** — supports `[N]` array-index
  segments alongside dotted keys (`items[0].item_name`,
  `a.b[2].c[1].d`, etc.) so cinch's `items[0]:key` GA4 access
  compiles on both adapters; and switches the DuckDB scalar-cast
  branch from `cast()` to `try_cast()` so non-matching values
  return NULL (matching Snowflake `VARIANT::T` semantics) instead
  of raising on, e.g., a `'false'` value reaching a numeric cast.

- **`SET TimeZone='UTC'` in `install_duckdb_compat`** — without this,
  DuckDB's session TimeZone defaults to the host's local TZ, breaking
  the `cast(timestamptz as timestamp)` idiom inside
  `nexus.convert_timezone`. Surfaces as boundary timestamps drifting
  by the local-UTC offset between Snowflake and DuckDB builds.
  Caught in cinch when the kafka chain's April 2026 dtc_leads count
  was +1,151 rows vs Snowflake; pinning the session to UTC closed
  the gap to +0 (down to ~+8 of real snapshot drift on partner_leads
  alone). Snowflake unaffected.

## Test plan

- [ ] Verify cinch's `google_analytics_4_events_normalized` and
      `direct_mail_sends` models compile + run on Snowflake (dev)
      with no behavior change.
- [ ] Verify same models compile + run on DuckDB target with the
      new variant access syntax rendering correctly.
- [ ] After cinch's [feat/duck-ga4-direct-mail branch](https://github.com/cinch-home-services/dw-ga4/tree/feat/duck-ga4-direct-mail)
      builds on duck end-to-end, confirm April 2026 `nexus_events`
      vs Snowflake parity (11/12 sources exact match including GA4
      and kafka).

🤖 Generated with [Claude Code](https://claude.com/claude-code)