### PR TITLE
fix(google_calendar): emit response_status, is_optional, is_organizer on event_participants

### DIFF
--- a/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
@@ -223,6 +223,9 @@ SELECT
     normalized_email as email,
     SPLIT(normalized_email, '@')[SAFE_OFFSET(1)] as domain,
     role,
+    response_status,
+    is_optional,
+    is_organizer,
     start_time,
     _ingested_at
 FROM participants_combined


### PR DESCRIPTION
## Summary
- Final `SELECT` in `google_calendar_event_participants.sql` only projected `role`, `start_time`, `_ingested_at` — even though the intermediate CTEs already computed `response_status`, `is_optional`, and `is_organizer` from the raw Google Calendar attendee JSON. The materialized table didn't carry the columns.
- Add those three columns to the final projection so downstream consumers can filter on per-attendee response state.

## Why this matters
Surfacing these enables attendance-quality analytics (e.g., distinguishing required vs optional invites, filtering accepted/tentative vs declined). Found while building a contacts-universe artifact at slide-rule-tech and discovering the join compiled but returned nothing useful — turned out the columns existed in the package source but never made it to the table.

## Test plan
- [ ] `dbt run --select google_calendar_event_participants` against a project with this source enabled.
- [ ] `SELECT response_status, is_optional, is_organizer, role, COUNT(*) FROM {{ ref('google_calendar_event_participants') }} GROUP BY 1,2,3,4 ORDER BY 5 DESC` — verify rows show populated values for attendee rows (accepted/declined/etc.) and NULLs for organizer/creator rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)