### PR TITLE
fix(json_path): TRY_CAST on Snowflake non-string casts

### DIFF
--- a/macros/cross-adapter/json.sql
+++ b/macros/cross-adapter/json.sql
@@ -62,7 +62,22 @@
     {%- endfor -%}
   {%- endset -%}
   {%- set sf_type = nexus._nexus_json_type_to_sf(type) -%}
-  {{ column }}{{ sf_path }}{%- if sf_type %}::{{ sf_type }}{%- endif -%}
+  {%- if sf_type and sf_type|lower not in ['string','varchar','text'] -%}
+    {# Non-string casts: extract as string first, then TRY_CAST.
+       Snowflake's bare VARIANT::TYPE cast raises a database error when
+       the variant value can't be coerced (e.g. the string 'false' cast
+       to NUMBER produces "Failed to cast variant value 'false' to
+       FIXED"). TRY_CAST gives NULL on failure — but TRY_CAST doesn't
+       accept VARIANT directly, only string-shaped inputs ("Function
+       TRY_CAST cannot be used with arguments of types VARIANT and
+       NUMBER(38,0)"). So we go variant → ::string → try_cast. Matches
+       the DuckDB branch below (which already returns NULL on bad
+       coercion) and replaces the typeof()-guarded variant access that
+       cinch's GA4 model used defensively. #}
+    try_cast({{ column }}{{ sf_path }}::string as {{ sf_type }})
+  {%- else -%}
+    {{ column }}{{ sf_path }}{%- if sf_type %}::{{ sf_type }}{%- endif -%}
+  {%- endif -%}
 {%- elif target.type == 'duckdb' -%}
   {%- set duck_path -%}
     '${%- for tok in tokens -%}


### PR DESCRIPTION
## Summary

Snowflake's bare \`VARIANT::TYPE\` form raises a database error when the underlying variant value can't be coerced — e.g. \`'false'::NUMBER\` produces:

\`\`\`
Failed to cast variant value \"false\" to FIXED
\`\`\`

The previous \`nexus.json_path\` macro emitted the bare cast on the assumption that Snowflake would silently NULL out (matching the DuckDB \`try_cast\` branch). It doesn't. Cinch's original GA4 normalized model wrapped each variant cast in a \`typeof()\` guard precisely because of this — when we removed those guards in favor of \`nexus.json_path\`, the duck path was safe but the Snowflake path regressed.

Switching the Snowflake non-string branch to \`TRY_CAST\` gives NULL on coercion failure, matching the DuckDB branch and restoring the defensive semantics. Strings stay on bare \`::string\` since string coercion is always defined.

## Test plan

- [ ] Cinch \`google_analytics_4_events_normalized\` on \`--target dev\` (Snowflake) builds without the \"Failed to cast variant value 'false' to FIXED\" error.
- [ ] Cinch \`google_analytics_4_events_normalized\` on \`--target duck\` continues to build (DuckDB branch unchanged).
- [ ] Tag v0.11.3 + bump cinch \`packages.yml\` from v0.11.2 → v0.11.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)