### PR TITLE
feat(cross-adapter): BigQuery branches + duck-side BQ-function shims

### DIFF
--- a/macros/cross-adapter/convert_timezone.sql
+++ b/macros/cross-adapter/convert_timezone.sql
@@ -37,6 +37,27 @@
   {%- else -%}
     cast(cast({{ column }} as timestamp) at time zone '{{ source_tz }}' at time zone '{{ target_tz }}' as timestamp)
   {%- endif -%}
+{%- elif target.type == 'bigquery' -%}
+  {#- BigQuery has no convert_timezone(). The equivalent: cast the
+      column to TIMESTAMP (UTC-anchored) and then convert via the
+      'AT TIME ZONE'-shape — BQ uses TIMESTAMP/DATETIME conversion
+      functions. TIMESTAMP() with a tz argument constructs a UTC
+      TIMESTAMP from a DATETIME interpreted in that source tz;
+      DATETIME() converts a TIMESTAMP into a DATETIME at the target
+      tz (giving you the "wall clock" in that zone).
+      Returns TIMESTAMP (UTC-anchored) for round-trip consistency
+      with the Snowflake/DuckDB branches. -#}
+  {%- if source_tz is none -%}
+    {#- 2-arg form: column already in UTC. Cast for safety; return
+        as TIMESTAMP. The DATETIME() call returns wall-clock at
+        target_tz, then TIMESTAMP(..., target_tz) re-anchors it. -#}
+    timestamp(datetime(cast({{ column }} as timestamp), '{{ target_tz }}'), '{{ target_tz }}')
+  {%- else -%}
+    {#- 3-arg form: column wall-clock is in source_tz. Treat as a
+        DATETIME (naive), build a TIMESTAMP anchored at source_tz,
+        then re-anchor wall-clock to target_tz. -#}
+    timestamp(datetime(timestamp(cast({{ column }} as datetime), '{{ source_tz }}'), '{{ target_tz }}'), '{{ target_tz }}')
+  {%- endif -%}
 {%- else -%}
   {#- Snowflake (and other adapters): emit the original
       convert_timezone() call shape verbatim. -#}

--- a/macros/cross-adapter/dedupe.sql
+++ b/macros/cross-adapter/dedupe.sql
@@ -13,9 +13,10 @@
     subquery + WHERE __rn = 1 form is semantically identical, portable
     across adapters, and dodges the bug.
 
-    On Snowflake we still emit the QUALIFY form for compiled-SQL
-    readability. On DuckDB (and as the safe default) we emit the
-    subquery form.
+    On Snowflake and BigQuery we emit the QUALIFY form (both support
+    it) for compiled-SQL readability. On DuckDB (and as the safe
+    default) we emit the subquery form, using `* EXCLUDE(__nexus_rn)`
+    on duck and `* EXCEPT(__nexus_rn)` on BigQuery for `cols='*'`.
 
     Args:
       source: CTE name or {{ ref('...') }} expression (string)
@@ -25,7 +26,7 @@
       cols: column list for the outer select (defaults to '*')
 #}
 {% macro dedupe(source, partition_by, order_by, cols='*') %}
-{%- if target.type == 'snowflake' -%}
+{%- if target.type == 'snowflake' or target.type == 'bigquery' -%}
 select {{ cols }} from {{ source }}
 qualify row_number() over (partition by {{ partition_by }} order by {{ order_by }}) = 1
 {%- else -%}

--- a/macros/cross-adapter/install_duckdb_compat.sql
+++ b/macros/cross-adapter/install_duckdb_compat.sql
@@ -59,7 +59,13 @@ CREATE OR REPLACE MACRO array_contains(needle, haystack) AS list_contains(haysta
 CREATE OR REPLACE MACRO json_extract_scalar(col, path) AS json_extract_string(col, path);
 -- json_extract returns JSON; unnest wants a LIST. Cast to JSON[] so
 -- UNNEST(JSON_EXTRACT_ARRAY(...)) works the same shape as on BQ.
-CREATE OR REPLACE MACRO json_extract_array(col, path) AS json_extract(col, path)::JSON[];
+-- BigQuery supports JSON_EXTRACT_ARRAY(col) (1-arg, returns root
+-- array) and JSON_EXTRACT_ARRAY(col, path) (2-arg). DuckDB MACROs
+-- can't be overloaded by arity (CREATE OR REPLACE replaces, doesn't
+-- add an overload), so we use a default `path := '$'` for the
+-- 1-arg form. json_extract(col, '$') returns the root value, which
+-- cast to JSON[] yields the array elements.
+CREATE OR REPLACE MACRO json_extract_array(col, path := '$') AS json_extract(col, path)::JSON[];
 -- ARRAY_LENGTH on a JSON array: cast then list length.
 CREATE OR REPLACE MACRO array_length(arr) AS len(arr);
 CREATE OR REPLACE MACRO to_json_string(col) AS cast(col AS varchar);
@@ -72,10 +78,37 @@ CREATE OR REPLACE MACRO parse_timestamp(fmt, s) AS strptime(s, fmt);
 CREATE OR REPLACE MACRO parse_date(fmt, s) AS cast(strptime(s, fmt) AS date);
 CREATE OR REPLACE MACRO timestamp_seconds(x) AS to_timestamp(x);
 CREATE OR REPLACE MACRO timestamp_micros(x) AS make_timestamp(x);
+CREATE OR REPLACE MACRO timestamp_millis(x) AS make_timestamp(x * 1000);
 CREATE OR REPLACE MACRO unix_seconds(x) AS cast(epoch(x) AS bigint);
 CREATE OR REPLACE MACRO unix_micros(x) AS cast(epoch_us(x) AS bigint);
 CREATE OR REPLACE MACRO parse_json(s) AS cast(s AS json);
 CREATE OR REPLACE MACRO regexp_contains(s, p) AS regexp_matches(s, p);
+-- BigQuery COUNTIF(cond) → duck's count_if(cond) (builtin since ~0.9).
+CREATE OR REPLACE MACRO countif(cond) AS count_if(cond);
+-- (ARRAY_CONCAT_AGG isn't shimmed — duck doesn't support aggregate
+-- macros, so call sites use a Jinja conditional with
+-- flatten(array_agg(arr)) on duck.)
+-- BigQuery's SPLIT(s, sep) → duck's string_split. List shape matches.
+CREATE OR REPLACE MACRO split(s, sep) AS string_split(s, sep);
+-- BigQuery/Snowflake's INITCAP isn't builtin in DuckDB (catalog
+-- error). Re-implement: lowercase the input, then for each space-
+-- separated word uppercase the first letter and concatenate.
+CREATE OR REPLACE MACRO initcap(s) AS
+    list_aggregate(
+        list_transform(
+            string_split(s, ' '),
+            x -> upper(substring(x, 1, 1)) || lower(substring(x, 2))
+        ),
+        'string_agg', ' '
+    );
+
+-- BigQuery SAFE_OFFSET(n) returns 0-indexed array element n (NULL out
+-- of bounds). DuckDB list indexing is 1-based, so translate by +1.
+-- Used inline as `arr[safe_offset(1)]` → arr[2] (second element).
+-- (Skipping the bare OFFSET shim — `offset` is a SQL reserved word in
+-- duck for LIMIT/OFFSET clauses; refactor those sites to safe_offset
+-- if needed.)
+CREATE OR REPLACE MACRO safe_offset(n) AS n + 1;
 -- BigQuery SAFE_CAST / SAFE.CAST returns NULL on cast failure. DuckDB
 -- has try_cast as the native equivalent. SAFE_CAST isn't a macro-
 -- definable function name in duck (the SAFE namespace is BQ-specific),

--- a/macros/cross-adapter/install_duckdb_compat.sql
+++ b/macros/cross-adapter/install_duckdb_compat.sql
@@ -65,6 +65,12 @@ CREATE OR REPLACE MACRO to_json_string(col) AS cast(col AS varchar);
 CREATE OR REPLACE MACRO timestamp(x) AS cast(x AS timestamp);
 CREATE OR REPLACE MACRO parse_timestamp(fmt, s) AS strptime(s, fmt);
 CREATE OR REPLACE MACRO parse_date(fmt, s) AS cast(strptime(s, fmt) AS date);
+CREATE OR REPLACE MACRO timestamp_seconds(x) AS to_timestamp(x);
+CREATE OR REPLACE MACRO timestamp_micros(x) AS make_timestamp(x);
+CREATE OR REPLACE MACRO unix_seconds(x) AS cast(epoch(x) AS bigint);
+CREATE OR REPLACE MACRO unix_micros(x) AS cast(epoch_us(x) AS bigint);
+CREATE OR REPLACE MACRO parse_json(s) AS cast(s AS json);
+CREATE OR REPLACE MACRO regexp_contains(s, p) AS regexp_matches(s, p);
 -- BigQuery SAFE_CAST / SAFE.CAST returns NULL on cast failure. DuckDB
 -- has try_cast as the native equivalent. SAFE_CAST isn't a macro-
 -- definable function name in duck (the SAFE namespace is BQ-specific),

--- a/macros/cross-adapter/install_duckdb_compat.sql
+++ b/macros/cross-adapter/install_duckdb_compat.sql
@@ -29,8 +29,9 @@ CREATE TYPE IF NOT EXISTS timestamp_tz AS TIMESTAMPTZ;
 CREATE TYPE IF NOT EXISTS variant AS JSON;
 
 -- BigQuery type aliases (string, int64, bool already valid in duck;
--- float64 is the one BQ-specific name that duck doesn't recognize).
+-- float64 + number are the BQ-specific names duck doesn't recognize).
 CREATE TYPE IF NOT EXISTS float64 AS DOUBLE;
+CREATE TYPE IF NOT EXISTS number AS DECIMAL(38,9);
 
 -- Snowflake scalar function aliases
 CREATE OR REPLACE MACRO current_timestamp() AS now();
@@ -57,6 +58,13 @@ CREATE OR REPLACE MACRO array_contains(needle, haystack) AS list_contains(haysta
 CREATE OR REPLACE MACRO json_extract_scalar(col, path) AS json_extract_string(col, path);
 CREATE OR REPLACE MACRO json_extract_array(col, path) AS json_extract(col, path);
 CREATE OR REPLACE MACRO to_json_string(col) AS cast(col AS varchar);
+-- BigQuery's TIMESTAMP(x) constructor: from a string or DATETIME,
+-- returns a TIMESTAMP. DuckDB equivalent: cast as timestamp. Wrapping
+-- in try_cast for parse-fail tolerance (BQ raises, so use plain cast
+-- if strict semantics are wanted).
+CREATE OR REPLACE MACRO timestamp(x) AS cast(x AS timestamp);
+CREATE OR REPLACE MACRO parse_timestamp(fmt, s) AS strptime(s, fmt);
+CREATE OR REPLACE MACRO parse_date(fmt, s) AS cast(strptime(s, fmt) AS date);
 -- BigQuery SAFE_CAST / SAFE.CAST returns NULL on cast failure. DuckDB
 -- has try_cast as the native equivalent. SAFE_CAST isn't a macro-
 -- definable function name in duck (the SAFE namespace is BQ-specific),

--- a/macros/cross-adapter/install_duckdb_compat.sql
+++ b/macros/cross-adapter/install_duckdb_compat.sql
@@ -41,6 +41,26 @@ CREATE OR REPLACE MACRO try_to_number(s) AS try_cast(s AS decimal(38,0));
 CREATE OR REPLACE MACRO array_construct() AS list_value();
 CREATE OR REPLACE MACRO array_contains(needle, haystack) AS list_contains(haystack, needle);
 
+-- BigQuery scalar function aliases (used by clients ported from BQ).
+-- These let BigQuery-shaped SQL like
+--     JSON_EXTRACT_SCALAR(_raw_record, '$.id')
+--     UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.lines'))
+--     TO_JSON_STRING(_raw_record)
+-- compile + run on duck without per-call refactoring. The cross-
+-- adapter nexus.json_path / nexus.try_to_date macros are still the
+-- preferred form for *new* code (they cover BQ/Snowflake/duck under
+-- one signature), but shims here unblock large existing BQ codebases.
+CREATE OR REPLACE MACRO json_extract_scalar(col, path) AS json_extract_string(col, path);
+CREATE OR REPLACE MACRO json_extract_array(col, path) AS json_extract(col, path);
+CREATE OR REPLACE MACRO to_json_string(col) AS cast(col AS varchar);
+-- BigQuery SAFE_CAST / SAFE.CAST returns NULL on cast failure. DuckDB
+-- has try_cast as the native equivalent. SAFE_CAST isn't a macro-
+-- definable function name in duck (the SAFE namespace is BQ-specific),
+-- so the cross-adapter approach for `SAFE.CAST` is to refactor to
+-- `try_cast`. We register safe_cast (underscore form) as the alias
+-- since duck accepts that as a function name.
+CREATE OR REPLACE MACRO safe_cast(col, "type") AS try_cast(col AS varchar);
+
 -- Disable expression_rewriter: bug where try_strptime + windowed dedup
 -- in a many-column CTAS surfaces as "invalid timestamp field format"
 -- against a column unrelated to the cast. Small (likely negligible)

--- a/macros/cross-adapter/install_duckdb_compat.sql
+++ b/macros/cross-adapter/install_duckdb_compat.sql
@@ -28,6 +28,10 @@ CREATE TYPE IF NOT EXISTS timestamp_ntz AS TIMESTAMP;
 CREATE TYPE IF NOT EXISTS timestamp_tz AS TIMESTAMPTZ;
 CREATE TYPE IF NOT EXISTS variant AS JSON;
 
+-- BigQuery type aliases (string, int64, bool already valid in duck;
+-- float64 is the one BQ-specific name that duck doesn't recognize).
+CREATE TYPE IF NOT EXISTS float64 AS DOUBLE;
+
 -- Snowflake scalar function aliases
 CREATE OR REPLACE MACRO current_timestamp() AS now();
 CREATE OR REPLACE MACRO iff(c, t, f) AS CASE WHEN c THEN t ELSE f END;

--- a/macros/cross-adapter/install_duckdb_compat.sql
+++ b/macros/cross-adapter/install_duckdb_compat.sql
@@ -28,10 +28,11 @@ CREATE TYPE IF NOT EXISTS timestamp_ntz AS TIMESTAMP;
 CREATE TYPE IF NOT EXISTS timestamp_tz AS TIMESTAMPTZ;
 CREATE TYPE IF NOT EXISTS variant AS JSON;
 
--- BigQuery type aliases (string, int64, bool already valid in duck;
--- float64 + number are the BQ-specific names duck doesn't recognize).
+-- BigQuery type aliases (int64, bool already valid in duck; float64,
+-- number, string are the BQ-specific names duck doesn't recognize).
 CREATE TYPE IF NOT EXISTS float64 AS DOUBLE;
 CREATE TYPE IF NOT EXISTS number AS DECIMAL(38,9);
+CREATE TYPE IF NOT EXISTS string AS VARCHAR;
 
 -- Snowflake scalar function aliases
 CREATE OR REPLACE MACRO current_timestamp() AS now();

--- a/macros/cross-adapter/install_duckdb_compat.sql
+++ b/macros/cross-adapter/install_duckdb_compat.sql
@@ -56,7 +56,11 @@ CREATE OR REPLACE MACRO array_contains(needle, haystack) AS list_contains(haysta
 -- preferred form for *new* code (they cover BQ/Snowflake/duck under
 -- one signature), but shims here unblock large existing BQ codebases.
 CREATE OR REPLACE MACRO json_extract_scalar(col, path) AS json_extract_string(col, path);
-CREATE OR REPLACE MACRO json_extract_array(col, path) AS json_extract(col, path);
+-- json_extract returns JSON; unnest wants a LIST. Cast to JSON[] so
+-- UNNEST(JSON_EXTRACT_ARRAY(...)) works the same shape as on BQ.
+CREATE OR REPLACE MACRO json_extract_array(col, path) AS json_extract(col, path)::JSON[];
+-- ARRAY_LENGTH on a JSON array: cast then list length.
+CREATE OR REPLACE MACRO array_length(arr) AS len(arr);
 CREATE OR REPLACE MACRO to_json_string(col) AS cast(col AS varchar);
 -- BigQuery's TIMESTAMP(x) constructor: from a string or DATETIME,
 -- returns a TIMESTAMP. DuckDB equivalent: cast as timestamp. Wrapping

--- a/macros/cross-adapter/interval_cast.sql
+++ b/macros/cross-adapter/interval_cast.sql
@@ -14,6 +14,12 @@
   {%- if try -%}try_cast({{ column }} as interval)
   {%- else -%}cast({{ column }} as interval)
   {%- endif -%}
+{%- elif target.type == 'bigquery' -%}
+  {#- BigQuery: cast(s as interval) — same form as DuckDB. SAFE_CAST
+      gives NULL on parse failure for the `try` branch. -#}
+  {%- if try -%}safe_cast({{ column }} as interval)
+  {%- else -%}cast({{ column }} as interval)
+  {%- endif -%}
 {%- else -%}
   {%- if try -%}try_cast({{ column }} as interval hour(9) to second(0))
   {%- else -%}cast({{ column }} as interval hour(9) to second(0))

--- a/macros/cross-adapter/regexp.sql
+++ b/macros/cross-adapter/regexp.sql
@@ -12,8 +12,15 @@
         (DuckDB string literals do NOT interpret backslashes — `'\d'`
          is the 2-char string `\d`, and the regex engine sees `\d`.)
 
-    BigQuery: REGEXP_EXTRACT(str, pattern) returns capture group 1 only;
-        group N not yet implemented here.
+    BigQuery: REGEXP_EXTRACT(str, pattern) returns capture group 1.
+        For group N > 1 BQ has no direct equivalent — we wrap the
+        pattern in (?:...) for the leading groups so the user's
+        target group lands as group 1. Specifically: take the input
+        pattern as "<prefix>(target)<suffix>" where target is the
+        Nth capture group, and rewrite to a pattern that only
+        captures target. This is approximate — fully general pattern
+        rewriting would need a real regex parser. For now the BQ
+        branch only supports group_num=1; groups > 1 raise.
 
     Usage:
       {{ nexus.regexp_extract_group('col', 'OPT-(\\d+)\\((.*)\\)', 2) }}
@@ -30,7 +37,10 @@
   {%- set sf_pattern = pattern | replace('\\', '\\\\') -%}
   regexp_substr({{ column }}, '{{ sf_pattern }}', 1, 1, 'e', {{ group_num }})
 {%- elif target.type == 'bigquery' -%}
-  regexp_extract({{ column }}, '{{ pattern }}')
+  {%- if group_num != 1 -%}
+    {{ exceptions.raise_compiler_error("nexus.regexp_extract_group() on BigQuery only supports group_num=1; for group N>1, rewrite the pattern so the target capture is the first group (wrap other groups as (?:...)) or use BQ's REGEXP_EXTRACT_ALL with offset.") }}
+  {%- endif -%}
+  regexp_extract({{ column }}, r'{{ pattern }}')
 {%- else -%}
   {{ exceptions.raise_compiler_error("nexus.regexp_extract_group() does not support target.type='" ~ target.type ~ "' yet") }}
 {%- endif -%}

--- a/macros/cross-adapter/try_to_date.sql
+++ b/macros/cross-adapter/try_to_date.sql
@@ -25,6 +25,16 @@
     {%- set fmt = fmt | replace('DD',   '%d') -%}
     try_cast(try_strptime({{ column }}, '{{ fmt }}') as date)
   {%- endif -%}
+{%- elif target.type == 'bigquery' -%}
+  {%- if snowflake_format is none -%}
+    safe_cast({{ column }} as date)
+  {%- else -%}
+    {%- set fmt = snowflake_format -%}
+    {%- set fmt = fmt | replace('YYYY', '%Y') -%}
+    {%- set fmt = fmt | replace('MM',   '%m') -%}
+    {%- set fmt = fmt | replace('DD',   '%d') -%}
+    safe.parse_date('{{ fmt }}', {{ column }})
+  {%- endif -%}
 {%- else -%}
   {%- if snowflake_format is none -%}
     try_to_date({{ column }})
@@ -46,6 +56,16 @@
     {%- set fmt = fmt | replace('MM',   '%m') -%}
     {%- set fmt = fmt | replace('DD',   '%d') -%}
     cast(strptime({{ column }}, '{{ fmt }}') as date)
+  {%- endif -%}
+{%- elif target.type == 'bigquery' -%}
+  {%- if snowflake_format is none -%}
+    cast({{ column }} as date)
+  {%- else -%}
+    {%- set fmt = snowflake_format -%}
+    {%- set fmt = fmt | replace('YYYY', '%Y') -%}
+    {%- set fmt = fmt | replace('MM',   '%m') -%}
+    {%- set fmt = fmt | replace('DD',   '%d') -%}
+    parse_date('{{ fmt }}', {{ column }})
   {%- endif -%}
 {%- else -%}
   {%- if snowflake_format is none -%}

--- a/macros/cross-adapter/try_to_timestamp.sql
+++ b/macros/cross-adapter/try_to_timestamp.sql
@@ -10,13 +10,17 @@
         try_cast(col as timestamp)       — no format string
         try_strptime(col, '<strptime format>')  — needs translation
 
-    Snowflake format → strptime translation:
+    BigQuery has SAFE.PARSE_TIMESTAMP (string + format) and
+    SAFE_CAST(col AS TIMESTAMP) (auto-detect ISO 8601).
+
+    Snowflake format → strptime/BQ translation:
         YYYY → %Y     MM → %m     DD → %d
         HH24 → %H     HH12 → %I   MI → %M     SS → %S
         AM   → %p
 
     Snowflake's behavior on parse failure: returns NULL.
     DuckDB's try_strptime / try_cast: same.
+    BigQuery's SAFE.PARSE_TIMESTAMP / SAFE_CAST: same.
 #}
 {% macro try_to_timestamp(column, snowflake_format=none) %}
 {%- if target.type == 'duckdb' -%}
@@ -34,6 +38,21 @@
     {%- set fmt = fmt | replace('AM',   '%p') -%}
     try_strptime({{ column }}, '{{ fmt }}')
   {%- endif -%}
+{%- elif target.type == 'bigquery' -%}
+  {%- if snowflake_format is none -%}
+    safe_cast({{ column }} as timestamp)
+  {%- else -%}
+    {%- set fmt = snowflake_format -%}
+    {%- set fmt = fmt | replace('YYYY', '%Y') -%}
+    {%- set fmt = fmt | replace('HH24', '%H') -%}
+    {%- set fmt = fmt | replace('HH12', '%I') -%}
+    {%- set fmt = fmt | replace('MM',   '%m') -%}
+    {%- set fmt = fmt | replace('DD',   '%d') -%}
+    {%- set fmt = fmt | replace('MI',   '%M') -%}
+    {%- set fmt = fmt | replace('SS',   '%S') -%}
+    {%- set fmt = fmt | replace('AM',   '%p') -%}
+    safe.parse_timestamp('{{ fmt }}', {{ column }})
+  {%- endif -%}
 {%- else -%}
   {%- if snowflake_format is none -%}
     try_to_timestamp({{ column }})
@@ -46,9 +65,14 @@
 
 {# try_to_timestamp_ntz: same as try_to_timestamp on DuckDB
     (it has no _ntz distinction). On Snowflake, emit the _ntz variant
-    so the original NTZ-typed result is preserved. #}
+    so the original NTZ-typed result is preserved. BigQuery has no
+    _ntz/_tz distinction at the type level — TIMESTAMP is UTC-anchored
+    and DATETIME is naive; using TIMESTAMP keeps cross-adapter
+    semantics aligned with Snowflake's UTC session. #}
 {% macro try_to_timestamp_ntz(column, snowflake_format=none) %}
 {%- if target.type == 'duckdb' -%}
+  {{ nexus.try_to_timestamp(column, snowflake_format) }}
+{%- elif target.type == 'bigquery' -%}
   {{ nexus.try_to_timestamp(column, snowflake_format) }}
 {%- else -%}
   {%- if snowflake_format is none -%}
@@ -61,7 +85,8 @@
 
 
 {# to_timestamp / to_timestamp_ntz: non-try variants. Snowflake raises on
-    bad input, DuckDB cast raises too. Functionally equivalent. #}
+    bad input, DuckDB cast raises too, BigQuery PARSE_TIMESTAMP raises.
+    Functionally equivalent. #}
 {% macro to_timestamp(column, snowflake_format=none) %}
 {%- if target.type == 'duckdb' -%}
   {%- if snowflake_format is none -%}
@@ -78,6 +103,21 @@
     {%- set fmt = fmt | replace('AM',   '%p') -%}
     strptime({{ column }}, '{{ fmt }}')
   {%- endif -%}
+{%- elif target.type == 'bigquery' -%}
+  {%- if snowflake_format is none -%}
+    cast({{ column }} as timestamp)
+  {%- else -%}
+    {%- set fmt = snowflake_format -%}
+    {%- set fmt = fmt | replace('YYYY', '%Y') -%}
+    {%- set fmt = fmt | replace('HH24', '%H') -%}
+    {%- set fmt = fmt | replace('HH12', '%I') -%}
+    {%- set fmt = fmt | replace('MM',   '%m') -%}
+    {%- set fmt = fmt | replace('DD',   '%d') -%}
+    {%- set fmt = fmt | replace('MI',   '%M') -%}
+    {%- set fmt = fmt | replace('SS',   '%S') -%}
+    {%- set fmt = fmt | replace('AM',   '%p') -%}
+    parse_timestamp('{{ fmt }}', {{ column }})
+  {%- endif -%}
 {%- else -%}
   {%- if snowflake_format is none -%}
     to_timestamp({{ column }})
@@ -91,15 +131,19 @@
 {# to_timestamp_ntz: Snowflake's polymorphic to_timestamp_ntz auto-
     detects input type (string → parse, bigint → epoch micros). DuckDB
     has separate functions: cast(s as timestamp) for strings,
-    make_timestamp(bigint) for micros. We can't auto-dispatch in a
-    macro since input type isn't known at compile time — so callers
-    pick the appropriate variant explicitly.
+    make_timestamp(bigint) for micros. BigQuery: TIMESTAMP_MICROS,
+    TIMESTAMP_SECONDS. We can't auto-dispatch in a macro since input
+    type isn't known at compile time — so callers pick the appropriate
+    variant explicitly.
 
     nexus_to_timestamp_ntz(col)            — string / generic case
     nexus_to_timestamp_ntz_from_micros(col) — bigint epoch microseconds
+    nexus_to_timestamp_ntz_from_seconds(col) — bigint epoch seconds
 #}
 {% macro to_timestamp_ntz(column) %}
 {%- if target.type == 'duckdb' -%}
+  cast({{ column }} as timestamp)
+{%- elif target.type == 'bigquery' -%}
   cast({{ column }} as timestamp)
 {%- else -%}
   to_timestamp_ntz({{ column }})
@@ -109,6 +153,8 @@
 {% macro to_timestamp_ntz_from_micros(column) %}
 {%- if target.type == 'duckdb' -%}
   make_timestamp({{ column }})
+{%- elif target.type == 'bigquery' -%}
+  timestamp_micros({{ column }})
 {%- else -%}
   to_timestamp_ntz({{ column }})
 {%- endif -%}
@@ -117,6 +163,8 @@
 {% macro to_timestamp_ntz_from_seconds(column) %}
 {%- if target.type == 'duckdb' -%}
   cast(to_timestamp({{ column }}) as timestamp)
+{%- elif target.type == 'bigquery' -%}
+  timestamp_seconds({{ column }})
 {%- else -%}
   to_timestamp_ntz({{ column }})
 {%- endif -%}

--- a/macros/helpers/extract_gmail_name.sql
+++ b/macros/helpers/extract_gmail_name.sql
@@ -1,7 +1,7 @@
 {% macro extract_gmail_name(email_column) %}
   CASE 
     WHEN TRIM({{ email_column }}) LIKE '%<%' AND TRIM({{ email_column }}) LIKE '%>%'
-    THEN TRIM(REGEXP_EXTRACT(TRIM({{ email_column }}), r'^([^<]+)<'))
+    THEN TRIM(REGEXP_EXTRACT(TRIM({{ email_column }}), {% if target.type == 'bigquery' %}r'^([^<]+)<'{% else %}'^([^<]+)<'{% endif %}))
     ELSE NULL
   END
 {% endmacro %}

--- a/macros/helpers/extract_gmail_name.sql
+++ b/macros/helpers/extract_gmail_name.sql
@@ -1,7 +1,7 @@
 {% macro extract_gmail_name(email_column) %}
   CASE 
     WHEN TRIM({{ email_column }}) LIKE '%<%' AND TRIM({{ email_column }}) LIKE '%>%'
-    THEN TRIM(REGEXP_EXTRACT(TRIM({{ email_column }}), {% if target.type == 'bigquery' %}r'^([^<]+)<'{% else %}'^([^<]+)<'{% endif %}))
+    THEN TRIM({% if target.type == 'bigquery' %}REGEXP_EXTRACT(TRIM({{ email_column }}), r'^([^<]+)<'){% else %}regexp_extract(TRIM({{ email_column }}), '^([^<]+)<', 1){% endif %})
     ELSE NULL
   END
 {% endmacro %}

--- a/macros/helpers/filter_non_generic_domains.sql
+++ b/macros/helpers/filter_non_generic_domains.sql
@@ -1,10 +1,29 @@
+{# `IN UNNEST([...])` is BigQuery syntax; Snowflake and DuckDB use the
+   plain `IN (...)` form. Render the in-list as a quoted SQL tuple
+   when not on BQ. #}
+{% macro _domain_in_list(domain_column, values) %}
+{%- if target.type == 'bigquery' -%}
+{{ domain_column }} IN UNNEST({{ values }})
+{%- else -%}
+{{ domain_column }} IN ({%- for v in values -%}'{{ v }}'{%- if not loop.last -%},{%- endif -%}{%- endfor -%})
+{%- endif -%}
+{% endmacro %}
+
+{% macro _domain_not_in_list(domain_column, values) %}
+{%- if target.type == 'bigquery' -%}
+{{ domain_column }} NOT IN UNNEST({{ values }})
+{%- else -%}
+{{ domain_column }} NOT IN ({%- for v in values -%}'{{ v }}'{%- if not loop.last -%},{%- endif -%}{%- endfor -%})
+{%- endif -%}
+{% endmacro %}
+
 {% macro filter_non_generic_domains(domain_column) %}
     {{ domain_column }} IS NOT NULL
     AND {{ domain_column }} != ''
     {% if var('email_domain_groups_include_list', none) %}
-        AND {{ domain_column }} IN UNNEST({{ var('email_domain_groups_include_list') }})
-        AND {{ domain_column }} NOT IN UNNEST({{ var('email_domain_groups_exclude_list', []) }})
+        AND {{ nexus._domain_in_list(domain_column, var('email_domain_groups_include_list')) }}
+        AND {{ nexus._domain_not_in_list(domain_column, var('email_domain_groups_exclude_list', [])) }}
     {% else %}
-        AND {{ domain_column }} NOT IN UNNEST({{ var('email_domain_groups_exclude_list', []) }})
+        AND {{ nexus._domain_not_in_list(domain_column, var('email_domain_groups_exclude_list', [])) }}
     {% endif %}
 {% endmacro %}

--- a/macros/helpers/html_decode.sql
+++ b/macros/helpers/html_decode.sql
@@ -9,19 +9,19 @@ REGEXP_REPLACE(
                     REGEXP_REPLACE(
                         REGEXP_REPLACE(
                             COALESCE({{ text }}, ''),
-                            r'&#39;', "'"  -- Apostrophe
+                            {% if target.type == 'bigquery' %}r'&#39;'{% else %}'&#39;'{% endif %}, {% if target.type == 'bigquery' %}"'"{% else %}''''{% endif %}  -- Apostrophe
                         ),
-                        r'&apos;', "'"  -- Apostrophe (named)
+                        {% if target.type == 'bigquery' %}r'&apos;'{% else %}'&apos;'{% endif %}, {% if target.type == 'bigquery' %}"'"{% else %}''''{% endif %}  -- Apostrophe (named)
                     ),
-                    r'&quot;', '"'  -- Double quote
+                    {% if target.type == 'bigquery' %}r'&quot;'{% else %}'&quot;'{% endif %}, '"'  -- Double quote
                 ),
-                r'&amp;', '&'  -- Ampersand
+                {% if target.type == 'bigquery' %}r'&amp;'{% else %}'&amp;'{% endif %}, '&'  -- Ampersand
             ),
-            r'&lt;', '<'  -- Less than
+            {% if target.type == 'bigquery' %}r'&lt;'{% else %}'&lt;'{% endif %}, '<'  -- Less than
         ),
-        r'&gt;', '>'  -- Greater than
+        {% if target.type == 'bigquery' %}r'&gt;'{% else %}'&gt;'{% endif %}, '>'  -- Greater than
     ),
-    r'&#160;', ' '  -- Non-breaking space
+    {% if target.type == 'bigquery' %}r'&#160;'{% else %}'&#160;'{% endif %}, ' '  -- Non-breaking space
 )
 {% endmacro %}
 

--- a/macros/helpers/parse_gmail_email.sql
+++ b/macros/helpers/parse_gmail_email.sql
@@ -1,7 +1,7 @@
 {% macro parse_gmail_email(email_column) %}
   CASE 
     WHEN TRIM({{ email_column }}) LIKE '%<%' AND TRIM({{ email_column }}) LIKE '%>%'
-    THEN REGEXP_EXTRACT(TRIM({{ email_column }}), {% if target.type == 'bigquery' %}r'<([^>]+)>'{% else %}'<([^>]+)>'{% endif %})
+    THEN {% if target.type == 'bigquery' %}REGEXP_EXTRACT(TRIM({{ email_column }}), r'<([^>]+)>'){% else %}regexp_extract(TRIM({{ email_column }}), '<([^>]+)>', 1){% endif %}
     ELSE TRIM({{ email_column }})
   END
 {% endmacro %}

--- a/macros/helpers/parse_gmail_email.sql
+++ b/macros/helpers/parse_gmail_email.sql
@@ -1,7 +1,7 @@
 {% macro parse_gmail_email(email_column) %}
   CASE 
     WHEN TRIM({{ email_column }}) LIKE '%<%' AND TRIM({{ email_column }}) LIKE '%>%'
-    THEN REGEXP_EXTRACT(TRIM({{ email_column }}), r'<([^>]+)>')
+    THEN REGEXP_EXTRACT(TRIM({{ email_column }}), {% if target.type == 'bigquery' %}r'<([^>]+)>'{% else %}'<([^>]+)>'{% endif %})
     ELSE TRIM({{ email_column }})
   END
 {% endmacro %}

--- a/models/metadata/nexus_events_metadata.sql
+++ b/models/metadata/nexus_events_metadata.sql
@@ -87,6 +87,12 @@ SELECT
                         ){% if not loop.last %},{% endif %}
                         {% endfor %}
                     ))::VARCHAR
+                {% elif target.type == 'duckdb' %}
+                    cast(to_json([
+                        {% for col in columns %}
+                        {'column_name': '{{ col.name }}', 'column_type': '{{ col.type }}'}{% if not loop.last %},{% endif %}
+                        {% endfor %}
+                    ]) AS VARCHAR)
                 {% else %}
                     TO_JSON_STRING([
                         {% for col in columns %}

--- a/models/sources/gmail/base/gmail_messages_base_dedupped.sql
+++ b/models/sources/gmail/base/gmail_messages_base_dedupped.sql
@@ -15,10 +15,10 @@ WITH source_data AS (
 ),
 
 deduplicated AS (
-    SELECT 
-        * EXCEPT(gmail_message_id),
+    SELECT
+        {% if target.type == 'duckdb' %}* EXCLUDE(gmail_message_id){% else %}* EXCEPT(gmail_message_id){% endif %},
         ROW_NUMBER() OVER (
-            PARTITION BY gmail_message_id 
+            PARTITION BY gmail_message_id
             ORDER BY _ingested_at DESC
         ) as rn
     FROM source_data

--- a/models/sources/gmail/gmail.yml
+++ b/models/sources/gmail/gmail.yml
@@ -8,6 +8,11 @@ sources:
     database:
       "{{ var('nexus', {}).get('sources', {}).get('gmail', {}).get('database',
       '') }}"
+    # See google_calendar.yml for the meta.external_location explanation.
+    meta:
+      external_location:
+        "{{ var('nexus', {}).get('sources', {}).get('gmail',
+        {}).get('external_location', '') }}"
     tables:
       - name: messages
         identifier:

--- a/models/sources/gmail/gmail.yml
+++ b/models/sources/gmail/gmail.yml
@@ -8,11 +8,18 @@ sources:
     database:
       "{{ var('nexus', {}).get('sources', {}).get('gmail', {}).get('database',
       '') }}"
-    # See google_calendar.yml for the meta.external_location explanation.
+    # On the duck-dev target, source is read from parquet under
+    #   $NEXUS_LOCAL_EXTRACTS/<schema>/<table>/*.parquet
+    # where <schema> is the per-client schema override (defaults to
+    # 'gmail'). Set NEXUS_LOCAL_EXTRACTS to the client's extracts dir
+    # (e.g. ~/projects/nexus-extracts/slide-rule-tech). Empty string
+    # if unset, which dbt-duckdb treats as no override (falls back to
+    # database/schema/identifier). No-op on warehouse targets.
     meta:
       external_location:
-        "{{ var('nexus', {}).get('sources', {}).get('gmail',
-        {}).get('external_location', '') }}"
+        "{{ env_var('NEXUS_LOCAL_EXTRACTS', '') }}/{{ var('nexus',
+        {}).get('sources', {}).get('gmail', {}).get('schema',
+        'gmail') }}/{name}/*.parquet"
     tables:
       - name: messages
         identifier:

--- a/models/sources/gmail/intermediate/gmail_thread_events.sql
+++ b/models/sources/gmail/intermediate/gmail_thread_events.sql
@@ -6,7 +6,7 @@
 
 -- Extract thread started events from normalized gmail threads
 SELECT
-    {{ nexus.create_nexus_id('event', ['thread_id', '"thread started"']) }} as event_id,
+    {{ nexus.create_nexus_id('event', ['thread_id', "'thread started'"]) }} as event_id,
     first_message_sent_at as occurred_at,
     'thread started' as event_name,
     'email' as event_type,

--- a/models/sources/gmail/normalized/gmail_message_participants.sql
+++ b/models/sources/gmail/normalized/gmail_message_participants.sql
@@ -29,9 +29,9 @@ grouped_participants AS (
         message_id,
         email,
         role,
-        ARRAY_AGG(participant_raw ORDER BY sent_at DESC, _ingested_at DESC LIMIT 1)[OFFSET(0)] as participant_raw,
-        ARRAY_AGG(name ORDER BY sent_at DESC, _ingested_at DESC LIMIT 1)[OFFSET(0)] as name,
-        ARRAY_AGG(domain ORDER BY sent_at DESC, _ingested_at DESC LIMIT 1)[OFFSET(0)] as domain,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(participant_raw ORDER BY sent_at DESC, _ingested_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(participant_raw ORDER BY sent_at DESC, _ingested_at DESC){% endif %} as participant_raw,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(name ORDER BY sent_at DESC, _ingested_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(name ORDER BY sent_at DESC, _ingested_at DESC){% endif %} as name,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(domain ORDER BY sent_at DESC, _ingested_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(domain ORDER BY sent_at DESC, _ingested_at DESC){% endif %} as domain,
         MAX(sent_at) as sent_at,
         MAX(_ingested_at) as _ingested_at
     FROM per_account_participants

--- a/models/sources/gmail/normalized/gmail_messages.sql
+++ b/models/sources/gmail/normalized/gmail_messages.sql
@@ -19,26 +19,26 @@ grouped_messages AS (
     SELECT 
         message_id_header as message_id,
         message_id_header,
-        ARRAY_AGG(in_reply_to ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as in_reply_to,
-        ARRAY_AGG(auto_submitted_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as auto_submitted_header,
-        ARRAY_AGG(precedence_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as precedence_header,
-        ARRAY_AGG(list_id_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as list_id_header,
-        ARRAY_AGG(list_unsubscribe_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as list_unsubscribe_header,
-        ARRAY_AGG(x_auto_response_suppress_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as x_auto_response_suppress_header,
-        ARRAY_AGG(x_autoreply_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as x_autoreply_header,
-        ARRAY_AGG(x_autorespond_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as x_autorespond_header,
-        LOGICAL_OR(COALESCE(is_automated_or_bulk_message, FALSE)) as is_automated_or_bulk_message,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(in_reply_to ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(in_reply_to ORDER BY sent_at DESC){% endif %} as in_reply_to,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(auto_submitted_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(auto_submitted_header ORDER BY sent_at DESC){% endif %} as auto_submitted_header,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(precedence_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(precedence_header ORDER BY sent_at DESC){% endif %} as precedence_header,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(list_id_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(list_id_header ORDER BY sent_at DESC){% endif %} as list_id_header,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(list_unsubscribe_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(list_unsubscribe_header ORDER BY sent_at DESC){% endif %} as list_unsubscribe_header,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(x_auto_response_suppress_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(x_auto_response_suppress_header ORDER BY sent_at DESC){% endif %} as x_auto_response_suppress_header,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(x_autoreply_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(x_autoreply_header ORDER BY sent_at DESC){% endif %} as x_autoreply_header,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(x_autorespond_header ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(x_autorespond_header ORDER BY sent_at DESC){% endif %} as x_autorespond_header,
+        {% if target.type == 'bigquery' %}LOGICAL_OR{% else %}BOOL_OR{% endif %}(COALESCE(is_automated_or_bulk_message, FALSE)) as is_automated_or_bulk_message,
         MAX(sent_at) as sent_at,
-        ARRAY_AGG(raw_subject ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as raw_subject,
-        ARRAY_AGG(subject ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as subject,
-        ARRAY_AGG(raw_record ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as raw_record,
-        ARRAY_AGG(snippet ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as snippet,
-        ARRAY_AGG(size_estimate ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as size_estimate,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(raw_subject ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(raw_subject ORDER BY sent_at DESC){% endif %} as raw_subject,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(subject ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(subject ORDER BY sent_at DESC){% endif %} as subject,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(raw_record ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(raw_record ORDER BY sent_at DESC){% endif %} as raw_record,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(snippet ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(snippet ORDER BY sent_at DESC){% endif %} as snippet,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(size_estimate ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(size_estimate ORDER BY sent_at DESC){% endif %} as size_estimate,
         'gmail' as source,
         MAX(_ingested_at) as _ingested_at,
         -- Get the latest gmail_thread_id and _account for joining with threads
-        ARRAY_AGG(gmail_thread_id ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as last_gmail_thread_id,
-        ARRAY_AGG(_account ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)] as _account,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(gmail_thread_id ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(gmail_thread_id ORDER BY sent_at DESC){% endif %} as last_gmail_thread_id,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(_account ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(_account ORDER BY sent_at DESC){% endif %} as _account,
         -- Create JSON object mapping email (stream_id) to gmail_message_id
         -- Format: {"email1": "message_id1", "email2": "message_id2"}
         CONCAT(
@@ -92,7 +92,7 @@ all_labels AS (
     FROM (
         SELECT 
             message_id_header,
-            ARRAY_CONCAT_AGG(label_ids) as label_ids
+            {% if target.type == 'bigquery' %}ARRAY_CONCAT_AGG(label_ids){% else %}flatten(array_agg(label_ids)){% endif %} as label_ids
         FROM per_account_messages
         WHERE message_id_header IS NOT NULL
         GROUP BY message_id_header

--- a/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_message_participants_by_account.sql
+++ b/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_message_participants_by_account.sql
@@ -25,19 +25,19 @@ headers_extracted AS (
         sent_at,
         _ingested_at,
         _account,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM {% if target.type == 'duckdb' %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as t(header){% else %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'message-id'
          LIMIT 1) as message_id_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM {% if target.type == 'duckdb' %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as t(header){% else %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'from'
          LIMIT 1) as from_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM {% if target.type == 'duckdb' %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as t(header){% else %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'to'
          LIMIT 1) as to_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM {% if target.type == 'duckdb' %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as t(header){% else %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'cc'
          LIMIT 1) as cc_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM {% if target.type == 'duckdb' %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as t(header){% else %}UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'bcc'
          LIMIT 1) as bcc_header
     FROM source_data
@@ -83,7 +83,7 @@ to_recipients_parsed AS (
         {{ nexus.parse_gmail_email('TRIM(recipient)') }} as parsed_email,
         {{ nexus.extract_gmail_name('TRIM(recipient)') }} as participant_name
     FROM headers_extracted h,
-    UNNEST(SPLIT(COALESCE(h.to_header, ''), ',')) as recipient
+    UNNEST(SPLIT(COALESCE(h.to_header, ''), ',')) as {% if target.type == 'duckdb' %}t(recipient){% else %}recipient{% endif %}
     WHERE h.to_header IS NOT NULL
     AND TRIM(recipient) != ''
 ),
@@ -114,7 +114,7 @@ cc_recipients_parsed AS (
         {{ nexus.parse_gmail_email('TRIM(recipient)') }} as parsed_email,
         {{ nexus.extract_gmail_name('TRIM(recipient)') }} as participant_name
     FROM headers_extracted h,
-    UNNEST(SPLIT(COALESCE(h.cc_header, ''), ',')) as recipient
+    UNNEST(SPLIT(COALESCE(h.cc_header, ''), ',')) as {% if target.type == 'duckdb' %}t(recipient){% else %}recipient{% endif %}
     WHERE h.cc_header IS NOT NULL
     AND TRIM(recipient) != ''
 ),
@@ -145,7 +145,7 @@ bcc_recipients_parsed AS (
         {{ nexus.parse_gmail_email('TRIM(recipient)') }} as parsed_email,
         {{ nexus.extract_gmail_name('TRIM(recipient)') }} as participant_name
     FROM headers_extracted h,
-    UNNEST(SPLIT(COALESCE(h.bcc_header, ''), ',')) as recipient
+    UNNEST(SPLIT(COALESCE(h.bcc_header, ''), ',')) as {% if target.type == 'duckdb' %}t(recipient){% else %}recipient{% endif %}
     WHERE h.bcc_header IS NOT NULL
     AND TRIM(recipient) != ''
 ),
@@ -230,8 +230,8 @@ SELECT
     participant_raw,
     TRIM(
         REGEXP_REPLACE(
-            REGEXP_REPLACE(participant_name, r'^[\'"]+', ''),
-            r'[\'"]+$', 
+            REGEXP_REPLACE(participant_name, {% if target.type == 'bigquery' %}r'^[\'"]+'{% else %}'^[''"]+'{% endif %}, ''),
+            {% if target.type == 'bigquery' %}r'[\'"]+$'{% else %}'[''"]+$'{% endif %},
             ''
         )
     ) as name,

--- a/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_messages_by_account.sql
+++ b/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_messages_by_account.sql
@@ -27,34 +27,34 @@ WITH source_data AS (
 headers_extracted AS (
     SELECT
         *,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'message-id'
          LIMIT 1) as message_id_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'subject'
          LIMIT 1) as subject_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'in-reply-to'
          LIMIT 1) as in_reply_to_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'auto-submitted'
          LIMIT 1) as auto_submitted_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'precedence'
          LIMIT 1) as precedence_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'list-id'
          LIMIT 1) as list_id_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'list-unsubscribe'
          LIMIT 1) as list_unsubscribe_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'x-auto-response-suppress'
          LIMIT 1) as x_auto_response_suppress_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'x-autoreply'
          LIMIT 1) as x_autoreply_header,
-        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as header
+        (SELECT JSON_EXTRACT_SCALAR(header, '$.value') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.headers')) as {% if target.type == 'duckdb' %}t(header){% else %}header{% endif %}
          WHERE LOWER(JSON_EXTRACT_SCALAR(header, '$.name')) = 'x-autorespond'
          LIMIT 1) as x_autorespond_header
     FROM source_data
@@ -140,7 +140,7 @@ cleaned_message AS (
         ) as subject,
 
         -- Labels
-        ARRAY(SELECT JSON_EXTRACT_SCALAR(label, '$') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.labelIds')) as label) as label_ids,
+        ARRAY(SELECT JSON_EXTRACT_SCALAR(label, '$') FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.labelIds')) as {% if target.type == 'duckdb' %}t(label){% else %}label{% endif %}) as label_ids,
 
         -- Message content
         {{ nexus.html_decode("JSON_EXTRACT_SCALAR(_raw_record, '$.snippet')") }} as snippet,

--- a/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_messages_by_account.sql
+++ b/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_messages_by_account.sql
@@ -65,7 +65,11 @@ participant_domain_summary AS (
         gmail_message_id,
         _account,
         COUNT(*) as participant_count,
+        {% if target.type == 'bigquery' -%}
         ARRAY_AGG(DISTINCT LOWER(domain) IGNORE NULLS ORDER BY LOWER(domain)) as participant_domains,
+        {%- else -%}
+        ARRAY_AGG(DISTINCT LOWER(domain) ORDER BY LOWER(domain)) FILTER (WHERE domain IS NOT NULL) as participant_domains,
+        {%- endif %}
         {% if internal_domains | length > 0 %}
         COUNTIF(
             domain IN (
@@ -121,16 +125,16 @@ cleaned_message AS (
                     REGEXP_REPLACE(
                         REGEXP_REPLACE(
                             COALESCE(subject_header, ''),
-                            r'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*',
+                            {% if target.type == 'bigquery' %}r'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*'{% else %}'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*'{% endif %},
                             ''
                         ),
-                        r'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*',
+                        {% if target.type == 'bigquery' %}r'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*'{% else %}'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*'{% endif %},
                         ''
                     ),
-                    r'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*',
+                    {% if target.type == 'bigquery' %}r'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*'{% else %}'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*'{% endif %},
                     ''
                 ),
-                r'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*',
+                {% if target.type == 'bigquery' %}r'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*'{% else %}'^([Rr][Ee]|[Ff][Ww][Dd]?):\s*'{% endif %},
                 ''
             )
         ) as subject,
@@ -142,7 +146,7 @@ cleaned_message AS (
         {{ nexus.html_decode("JSON_EXTRACT_SCALAR(_raw_record, '$.snippet')") }} as snippet,
         CAST(JSON_EXTRACT_SCALAR(_raw_record, '$.sizeEstimate') AS INT64) as size_estimate,
         (
-            REGEXP_CONTAINS(LOWER(COALESCE(auto_submitted_header, '')), r'^auto-')
+            REGEXP_CONTAINS(LOWER(COALESCE(auto_submitted_header, '')), {% if target.type == 'bigquery' %}r'^auto-'{% else %}'^auto-'{% endif %})
             OR LOWER(COALESCE(precedence_header, '')) IN ('bulk', 'list', 'junk')
             OR COALESCE(NULLIF(TRIM(list_id_header), ''), NULL) IS NOT NULL
             OR COALESCE(NULLIF(TRIM(list_unsubscribe_header), ''), NULL) IS NOT NULL
@@ -167,17 +171,26 @@ cleaned_message AS (
 filtered_message AS (
     SELECT
         cm.*,
-        COALESCE(pds.participant_domains, CAST([] AS ARRAY<STRING>)) as participant_domains,
+        COALESCE(pds.participant_domains, {% if target.type == 'bigquery' %}CAST([] AS ARRAY<STRING>){% else %}CAST([] AS VARCHAR[]){% endif %}) as participant_domains,
         (
             COALESCE(pds.participant_count, 0) > 0
             AND COALESCE(pds.external_participant_count, 0) = 0
         ) as is_internal_only_message,
+        {% if target.type == 'bigquery' -%}
         TO_JSON_STRING(STRUCT(
             COALESCE(pds.participant_count, 0) as participant_count,
             COALESCE(pds.internal_participant_count, 0) as internal_participant_count,
             COALESCE(pds.external_participant_count, 0) as external_participant_count,
             COALESCE(pds.participant_domains, CAST([] AS ARRAY<STRING>)) as domains
         )) as participant_domain_summary
+        {%- else -%}
+        cast(to_json({
+            'participant_count': COALESCE(pds.participant_count, 0),
+            'internal_participant_count': COALESCE(pds.internal_participant_count, 0),
+            'external_participant_count': COALESCE(pds.external_participant_count, 0),
+            'domains': COALESCE(pds.participant_domains, CAST([] AS VARCHAR[]))
+        }) AS varchar) as participant_domain_summary
+        {%- endif %}
     FROM cleaned_message cm
     LEFT JOIN participant_domain_summary pds
         ON cm.gmail_message_id = pds.gmail_message_id

--- a/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_thread_participants_by_account.sql
+++ b/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_thread_participants_by_account.sql
@@ -38,8 +38,8 @@ thread_participants AS (
         gmail_thread_id,
         _account,
         email,
-        ARRAY_AGG(name ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)] as name,
-        ARRAY_AGG(participant_raw ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)] as participant_raw,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(name ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(name ORDER BY sent_at ASC){% endif %} as name,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(participant_raw ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(participant_raw ORDER BY sent_at ASC){% endif %} as participant_raw,
         domain,
         ARRAY_AGG(role) as roles_raw,
         MIN(sent_at) as first_participated_at,
@@ -59,7 +59,7 @@ SELECT
     domain,
     ARRAY(
         SELECT DISTINCT role 
-        FROM UNNEST(roles_raw) as role
+        FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}
         ORDER BY 
             CASE role 
                 WHEN 'sender' THEN 1
@@ -74,10 +74,10 @@ SELECT
 FROM thread_participants
 ORDER BY gmail_thread_id, 
     CASE 
-        WHEN 'sender' IN (SELECT role FROM UNNEST(roles_raw) as role) THEN 1
-        WHEN 'recipient' IN (SELECT role FROM UNNEST(roles_raw) as role) THEN 2
-        WHEN 'cced' IN (SELECT role FROM UNNEST(roles_raw) as role) THEN 3
-        WHEN 'bcced' IN (SELECT role FROM UNNEST(roles_raw) as role) THEN 4
+        WHEN 'sender' IN (SELECT role FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}) THEN 1
+        WHEN 'recipient' IN (SELECT role FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}) THEN 2
+        WHEN 'cced' IN (SELECT role FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}) THEN 3
+        WHEN 'bcced' IN (SELECT role FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}) THEN 4
         ELSE 5
     END,
     first_participated_at ASC,

--- a/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_threads_by_account.sql
+++ b/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_threads_by_account.sql
@@ -21,8 +21,8 @@ thread_summary AS (
         COUNT(DISTINCT gmail_message_id) as gmail_message_count,
         
         -- Subject (use the earliest message's subject)
-        ARRAY_AGG(subject ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)] as subject,
-        ARRAY_AGG(raw_subject ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)] as raw_subject,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(subject ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(subject ORDER BY sent_at ASC){% endif %} as subject,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(raw_subject ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(raw_subject ORDER BY sent_at ASC){% endif %} as raw_subject,
         
         -- Timestamps
         MIN(sent_at) as first_message_sent_at,
@@ -31,10 +31,10 @@ thread_summary AS (
         MAX(_ingested_at) as last_ingested_at,
         
         -- Root message info (earliest gmail_message_id)
-        ARRAY_AGG(gmail_message_id ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)] as root_gmail_message_id,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(gmail_message_id ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(gmail_message_id ORDER BY sent_at ASC){% endif %} as root_gmail_message_id,
         
         -- First message_id_header (earliest message's message_id_header for cross-account linking)
-        ARRAY_AGG(message_id_header ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)] as first_message_id_header,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(message_id_header ORDER BY sent_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(message_id_header ORDER BY sent_at ASC){% endif %} as first_message_id_header,
         
         -- Gmail message IDs in thread
         ARRAY_AGG(DISTINCT gmail_message_id) as gmail_message_ids
@@ -60,7 +60,7 @@ thread_labels AS (
             gmail_thread_id,
             _account,
             _stream_id,
-            ARRAY_CONCAT_AGG(label_ids) as label_ids
+            {% if target.type == 'bigquery' %}ARRAY_CONCAT_AGG(label_ids){% else %}flatten(array_agg(label_ids)){% endif %} as label_ids
         FROM messages
         WHERE gmail_thread_id IS NOT NULL
           AND _account IS NOT NULL

--- a/models/sources/gmail/normalized/gmail_thread_participants.sql
+++ b/models/sources/gmail/normalized/gmail_thread_participants.sql
@@ -35,10 +35,10 @@ thread_participants AS (
     SELECT
         thread_id,
         email,
-        ARRAY_AGG(name ORDER BY first_participated_at ASC LIMIT 1)[OFFSET(0)] as name,
-        ARRAY_AGG(participant_raw ORDER BY first_participated_at ASC LIMIT 1)[OFFSET(0)] as participant_raw,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(name ORDER BY first_participated_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(name ORDER BY first_participated_at ASC){% endif %} as name,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(participant_raw ORDER BY first_participated_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(participant_raw ORDER BY first_participated_at ASC){% endif %} as participant_raw,
         domain,
-        ARRAY_CONCAT_AGG(roles) as roles_raw,
+        {% if target.type == 'bigquery' %}ARRAY_CONCAT_AGG(roles){% else %}flatten(array_agg(roles)){% endif %} as roles_raw,
         MIN(first_participated_at) as first_participated_at,
         MAX(last_participated_at) as last_participated_at,
         MIN(_ingested_at) as _ingested_at

--- a/models/sources/gmail/normalized/gmail_thread_participants.sql
+++ b/models/sources/gmail/normalized/gmail_thread_participants.sql
@@ -56,7 +56,7 @@ SELECT
     domain,
     ARRAY(
         SELECT DISTINCT role 
-        FROM UNNEST(roles_raw) as role
+        FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}
         ORDER BY 
             CASE role 
                 WHEN 'sender' THEN 1
@@ -71,10 +71,10 @@ SELECT
 FROM thread_participants
 ORDER BY thread_id, 
     CASE 
-        WHEN 'sender' IN (SELECT role FROM UNNEST(roles_raw) as role) THEN 1
-        WHEN 'recipient' IN (SELECT role FROM UNNEST(roles_raw) as role) THEN 2
-        WHEN 'cced' IN (SELECT role FROM UNNEST(roles_raw) as role) THEN 3
-        WHEN 'bcced' IN (SELECT role FROM UNNEST(roles_raw) as role) THEN 4
+        WHEN 'sender' IN (SELECT role FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}) THEN 1
+        WHEN 'recipient' IN (SELECT role FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}) THEN 2
+        WHEN 'cced' IN (SELECT role FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}) THEN 3
+        WHEN 'bcced' IN (SELECT role FROM UNNEST(roles_raw) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}) THEN 4
         ELSE 5
     END,
     first_participated_at ASC,

--- a/models/sources/gmail/normalized/gmail_threads.sql
+++ b/models/sources/gmail/normalized/gmail_threads.sql
@@ -12,8 +12,8 @@ WITH per_account_threads AS (
 grouped as (
     SELECT 
         first_message_id_header as thread_id,
-        ARRAY_AGG(subject ORDER BY first_message_sent_at ASC LIMIT 1)[OFFSET(0)] as subject,
-        ARRAY_AGG(raw_subject ORDER BY first_message_sent_at ASC LIMIT 1)[OFFSET(0)] as raw_subject,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(subject ORDER BY first_message_sent_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(subject ORDER BY first_message_sent_at ASC){% endif %} as subject,
+        {% if target.type == 'bigquery' %}ARRAY_AGG(raw_subject ORDER BY first_message_sent_at ASC LIMIT 1)[OFFSET(0)]{% else %}first(raw_subject ORDER BY first_message_sent_at ASC){% endif %} as raw_subject,
         MIN(first_message_sent_at) as first_message_sent_at,
         MAX(last_message_sent_at) as last_message_sent_at,
         
@@ -60,7 +60,7 @@ all_labels AS (
     FROM (
         SELECT 
             first_message_id_header,
-            ARRAY_CONCAT_AGG(label_ids) as label_ids
+            {% if target.type == 'bigquery' %}ARRAY_CONCAT_AGG(label_ids){% else %}flatten(array_agg(label_ids)){% endif %} as label_ids
         FROM per_account_threads
         WHERE first_message_id_header IS NOT NULL
         GROUP BY first_message_id_header

--- a/models/sources/google_calendar/base/google_calendar_events_base_dedupped.sql
+++ b/models/sources/google_calendar/base/google_calendar_events_base_dedupped.sql
@@ -9,14 +9,17 @@ WITH source_data AS (
         *,
         JSON_EXTRACT_SCALAR(_raw_record, '$.id') AS calendar_event_id,
         JSON_EXTRACT_SCALAR(_raw_record, '$.iCalUID') AS ical_uid,
-        CAST(PARSE_TIMESTAMP(
-            '%Y-%m-%dT%H:%M:%E*S%Ez',
+        -- ISO 8601 with fractional seconds + tz offset. BQ needs
+        -- PARSE_TIMESTAMP with %E*S/%Ez format codes (duck strptime
+        -- doesn't recognize). try_cast on both adapters auto-detects
+        -- ISO 8601 and is equivalent for this format.
+        try_cast(
             COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.originalStartTime.dateTime'),
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            )
-        ) AS TIMESTAMP) AS instance_start,
+            ) AS TIMESTAMP
+        ) AS instance_start,
         CASE
             WHEN JSON_EXTRACT_SCALAR(_raw_record, '$.recurringEventId') IS NOT NULL THEN TRUE
             WHEN JSON_EXTRACT_ARRAY(_raw_record, '$.recurrence') IS NOT NULL
@@ -32,7 +35,7 @@ with_event_key AS (
     SELECT
         *,
         CASE
-            WHEN is_recurring THEN CONCAT(ical_uid, '|', CAST(instance_start AS STRING))
+            WHEN is_recurring THEN CONCAT(ical_uid, '|', CAST(instance_start AS VARCHAR))
             ELSE ical_uid
         END AS event_key
     FROM source_data

--- a/models/sources/google_calendar/base/google_calendar_events_base_dedupped.sql
+++ b/models/sources/google_calendar/base/google_calendar_events_base_dedupped.sql
@@ -13,13 +13,15 @@ WITH source_data AS (
         -- PARSE_TIMESTAMP with %E*S/%Ez format codes (duck strptime
         -- doesn't recognize). try_cast on both adapters auto-detects
         -- ISO 8601 and is equivalent for this format.
-        try_cast(
-            COALESCE(
+        {% if target.type == 'bigquery' %}SAFE_CAST(COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.originalStartTime.dateTime'),
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            ) AS TIMESTAMP
-        ) AS instance_start,
+            ) AS TIMESTAMP){% else %}try_cast(COALESCE(
+                JSON_EXTRACT_SCALAR(_raw_record, '$.originalStartTime.dateTime'),
+                JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
+                CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
+            ) AS TIMESTAMP){% endif %} AS instance_start,
         CASE
             WHEN JSON_EXTRACT_SCALAR(_raw_record, '$.recurringEventId') IS NOT NULL THEN TRUE
             WHEN JSON_EXTRACT_ARRAY(_raw_record, '$.recurrence') IS NOT NULL

--- a/models/sources/google_calendar/google_calendar.yml
+++ b/models/sources/google_calendar/google_calendar.yml
@@ -9,6 +9,11 @@ sources:
     database:
       "{{ var('nexus', {}).get('sources', {}).get('google_calendar',
       {}).get('database', '') }}"
+    # See gmail.yml for the meta.external_location explanation.
+    meta:
+      external_location:
+        "{{ var('nexus', {}).get('sources', {}).get('google_calendar',
+        {}).get('external_location', '') }}"
     tables:
       - name: events
         identifier:

--- a/models/sources/google_calendar/google_calendar.yml
+++ b/models/sources/google_calendar/google_calendar.yml
@@ -9,11 +9,14 @@ sources:
     database:
       "{{ var('nexus', {}).get('sources', {}).get('google_calendar',
       {}).get('database', '') }}"
-    # See gmail.yml for the meta.external_location explanation.
+    # See gmail.yml for the meta.external_location pattern: parquet
+    # under $NEXUS_LOCAL_EXTRACTS/<schema>/<table>/*.parquet on the
+    # duck-dev target. No-op on warehouse targets.
     meta:
       external_location:
-        "{{ var('nexus', {}).get('sources', {}).get('google_calendar',
-        {}).get('external_location', '') }}"
+        "{{ env_var('NEXUS_LOCAL_EXTRACTS', '') }}/{{ var('nexus',
+        {}).get('sources', {}).get('google_calendar', {}).get('schema',
+        'google_calendar') }}/{name}/*.parquet"
     tables:
       - name: events
         identifier:

--- a/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
@@ -12,20 +12,23 @@ WITH source_data AS (
         JSON_EXTRACT_SCALAR(_raw_record, '$.id') as calendar_event_id,
         JSON_EXTRACT_SCALAR(_raw_record, '$.iCalUID') as ical_uid,
         -- Determine instanceStart for recurring events
-        try_cast(
-            COALESCE(
+        {% if target.type == 'bigquery' %}SAFE_CAST(COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.originalStartTime.dateTime'),
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            ) AS TIMESTAMP
-        ) as instance_start,
-        -- Parse start_time for event timing
-        try_cast(
-            COALESCE(
+            ) AS TIMESTAMP){% else %}try_cast(COALESCE(
+                JSON_EXTRACT_SCALAR(_raw_record, '$.originalStartTime.dateTime'),
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            ) AS TIMESTAMP
-        ) as start_time,
+            ) AS TIMESTAMP){% endif %} as instance_start,
+        -- Parse start_time for event timing
+        {% if target.type == 'bigquery' %}SAFE_CAST(COALESCE(
+                JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
+                CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
+            ) AS TIMESTAMP){% else %}try_cast(COALESCE(
+                JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
+                CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
+            ) AS TIMESTAMP){% endif %} as start_time,
         -- Check if it's a recurring event
         CASE 
             WHEN JSON_EXTRACT_SCALAR(_raw_record, '$.recurringEventId') IS NOT NULL THEN true

--- a/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
@@ -167,7 +167,7 @@ attendees_raw AS (
         CAST(JSON_EXTRACT_SCALAR(attendee, '$.optional') AS BOOL) as is_optional,
         CAST(JSON_EXTRACT_SCALAR(attendee, '$.organizer') AS BOOL) as is_organizer
     FROM with_event_key s,
-    UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.attendees')) as attendee
+    UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.attendees')) as {% if target.type == 'duckdb' %}t(attendee){% else %}attendee{% endif %}
     WHERE JSON_EXTRACT_SCALAR(attendee, '$.email') IS NOT NULL
       AND JSON_EXTRACT_SCALAR(attendee, '$.email') != ''
 ),

--- a/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
@@ -12,20 +12,20 @@ WITH source_data AS (
         JSON_EXTRACT_SCALAR(_raw_record, '$.id') as calendar_event_id,
         JSON_EXTRACT_SCALAR(_raw_record, '$.iCalUID') as ical_uid,
         -- Determine instanceStart for recurring events
-        CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*S%Ez', 
+        try_cast(
             COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.originalStartTime.dateTime'),
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            )
-        ) AS TIMESTAMP) as instance_start,
+            ) AS TIMESTAMP
+        ) as instance_start,
         -- Parse start_time for event timing
-        CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*S%Ez', 
+        try_cast(
             COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            )
-        ) AS TIMESTAMP) as start_time,
+            ) AS TIMESTAMP
+        ) as start_time,
         -- Check if it's a recurring event
         CASE 
             WHEN JSON_EXTRACT_SCALAR(_raw_record, '$.recurringEventId') IS NOT NULL THEN true
@@ -62,10 +62,10 @@ organizer_raw AS (
         start_time,
         _ingested_at,
         JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email') as participant_raw,
-        {{ nexus.parse_gmail_email('JSON_EXTRACT_SCALAR(_raw_record, "$.organizer.email")') }} as parsed_email,
+        {{ nexus.parse_gmail_email("JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email')") }} as parsed_email,
         COALESCE(
             JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.displayName'),
-            {{ nexus.extract_gmail_name('JSON_EXTRACT_SCALAR(_raw_record, "$.organizer.email")') }}
+            {{ nexus.extract_gmail_name("JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email')") }}
         ) as participant_name,
         'organizer' as role,
         JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.displayName') as display_name,
@@ -107,10 +107,10 @@ creator_raw AS (
         start_time,
         _ingested_at,
         JSON_EXTRACT_SCALAR(_raw_record, '$.creator.email') as participant_raw,
-        {{ nexus.parse_gmail_email('JSON_EXTRACT_SCALAR(_raw_record, "$.creator.email")') }} as parsed_email,
+        {{ nexus.parse_gmail_email("JSON_EXTRACT_SCALAR(_raw_record, '$.creator.email')") }} as parsed_email,
         COALESCE(
             JSON_EXTRACT_SCALAR(_raw_record, '$.creator.displayName'),
-            {{ nexus.extract_gmail_name('JSON_EXTRACT_SCALAR(_raw_record, "$.creator.email")') }}
+            {{ nexus.extract_gmail_name("JSON_EXTRACT_SCALAR(_raw_record, '$.creator.email')") }}
         ) as participant_name,
         'creator' as role,
         JSON_EXTRACT_SCALAR(_raw_record, '$.creator.displayName') as display_name,
@@ -155,10 +155,10 @@ attendees_raw AS (
         s.start_time,
         s._ingested_at,
         JSON_EXTRACT_SCALAR(attendee, '$.email') as participant_raw,
-        {{ nexus.parse_gmail_email('JSON_EXTRACT_SCALAR(attendee, "$.email")') }} as parsed_email,
+        {{ nexus.parse_gmail_email("JSON_EXTRACT_SCALAR(attendee, '$.email')") }} as parsed_email,
         COALESCE(
             JSON_EXTRACT_SCALAR(attendee, '$.displayName'),
-            {{ nexus.extract_gmail_name('JSON_EXTRACT_SCALAR(attendee, "$.email")') }}
+            {{ nexus.extract_gmail_name("JSON_EXTRACT_SCALAR(attendee, '$.email')") }}
         ) as participant_name,
         'attendee' as role,
         JSON_EXTRACT_SCALAR(attendee, '$.displayName') as display_name,
@@ -212,11 +212,11 @@ SELECT
     TRIM(
         REGEXP_REPLACE(
             REGEXP_REPLACE(
-                REGEXP_REPLACE(participant_name, r'^[\'"]+', ''),
-                r'[\'"]+$',
+                REGEXP_REPLACE(participant_name, {% if target.type == 'bigquery' %}r'^[\'"]+'{% else %}'^[''"]+'{% endif %}, ''),
+                {% if target.type == 'bigquery' %}r'[\'"]+$'{% else %}'[''"]+$'{% endif %},
                 ''
             ),
-            r'\s*\([^)]*@[^)]*\)\s*$',
+            {% if target.type == 'bigquery' %}r'\s*\([^)]*@[^)]*\)\s*$'{% else %}'\s*\([^)]*@[^)]*\)\s*$'{% endif %},
             ''
         )
     ) as name,

--- a/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
@@ -33,13 +33,13 @@ extracted AS (
         
         -- Determine instanceStart for recurring events
         -- Priority: originalStartTime.dateTime > start.dateTime > start.date
-        CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*S%Ez', 
+        try_cast(
             COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.originalStartTime.dateTime'),
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            )
-        ) AS TIMESTAMP) as instance_start,
+            ) AS TIMESTAMP
+        ) as instance_start,
         
         -- Event details
         JSON_EXTRACT_SCALAR(_raw_record, '$.summary') as summary,
@@ -48,19 +48,19 @@ extracted AS (
         JSON_EXTRACT_SCALAR(_raw_record, '$.status') as status,
         
         -- Parse start and end times
-        CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*S%Ez', 
+        try_cast(
             COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            )
-        ) AS TIMESTAMP) as start_time,
+            ) AS TIMESTAMP
+        ) as start_time,
         
-        CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E*S%Ez', 
+        try_cast(
             COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.end.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.end.date'), 'T23:59:59Z')
-            )
-        ) AS TIMESTAMP) as end_time,
+            ) AS TIMESTAMP
+        ) as end_time,
         
         -- Check if it's all day event
         CASE 
@@ -83,7 +83,7 @@ extracted AS (
             SELECT COUNT(*) > 0
             FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.attendees')) as attendee
             WHERE JSON_EXTRACT_SCALAR(attendee, '$.email') IS NOT NULL
-              AND REGEXP_EXTRACT(JSON_EXTRACT_SCALAR(attendee, '$.email'), r'@(.+)') NOT IN (
+              AND REGEXP_EXTRACT(JSON_EXTRACT_SCALAR(attendee, '$.email'), {% if target.type == 'bigquery' %}r'@(.+)'{% else %}'@(.+)'{% endif %}) NOT IN (
                   {%- for domain in var('internal_domains', []) -%}
                   '{{ domain }}'
                   {%- if not loop.last -%},{%- endif -%}
@@ -91,7 +91,7 @@ extracted AS (
               )
         ) OR (
             JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email') IS NOT NULL
-            AND REGEXP_EXTRACT(JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email'), r'@(.+)') NOT IN (
+            AND REGEXP_EXTRACT(JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email'), {% if target.type == 'bigquery' %}r'@(.+)'{% else %}'@(.+)'{% endif %}) NOT IN (
                 {%- for domain in var('internal_domains', []) -%}
                 '{{ domain }}'
                 {%- if not loop.last -%},{%- endif -%}
@@ -120,7 +120,7 @@ with_composite_key AS (
         -- Use iCalUID as primary key for single events
         -- Use iCalUID + instanceStart for recurring events
         CASE 
-            WHEN is_recurring THEN CONCAT(ical_uid, '|', CAST(instance_start AS STRING))
+            WHEN is_recurring THEN CONCAT(ical_uid, '|', CAST(instance_start AS VARCHAR))
             ELSE ical_uid
         END as event_key
     FROM extracted

--- a/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
@@ -33,13 +33,15 @@ extracted AS (
         
         -- Determine instanceStart for recurring events
         -- Priority: originalStartTime.dateTime > start.dateTime > start.date
-        try_cast(
-            COALESCE(
+        {% if target.type == 'bigquery' %}SAFE_CAST(COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.originalStartTime.dateTime'),
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            ) AS TIMESTAMP
-        ) as instance_start,
+            ) AS TIMESTAMP){% else %}try_cast(COALESCE(
+                JSON_EXTRACT_SCALAR(_raw_record, '$.originalStartTime.dateTime'),
+                JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
+                CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
+            ) AS TIMESTAMP){% endif %} as instance_start,
         
         -- Event details
         JSON_EXTRACT_SCALAR(_raw_record, '$.summary') as summary,
@@ -48,19 +50,21 @@ extracted AS (
         JSON_EXTRACT_SCALAR(_raw_record, '$.status') as status,
         
         -- Parse start and end times
-        try_cast(
-            COALESCE(
+        {% if target.type == 'bigquery' %}SAFE_CAST(COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
-            ) AS TIMESTAMP
-        ) as start_time,
+            ) AS TIMESTAMP){% else %}try_cast(COALESCE(
+                JSON_EXTRACT_SCALAR(_raw_record, '$.start.dateTime'),
+                CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.start.date'), 'T00:00:00Z')
+            ) AS TIMESTAMP){% endif %} as start_time,
         
-        try_cast(
-            COALESCE(
+        {% if target.type == 'bigquery' %}SAFE_CAST(COALESCE(
                 JSON_EXTRACT_SCALAR(_raw_record, '$.end.dateTime'),
                 CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.end.date'), 'T23:59:59Z')
-            ) AS TIMESTAMP
-        ) as end_time,
+            ) AS TIMESTAMP){% else %}try_cast(COALESCE(
+                JSON_EXTRACT_SCALAR(_raw_record, '$.end.dateTime'),
+                CONCAT(JSON_EXTRACT_SCALAR(_raw_record, '$.end.date'), 'T23:59:59Z')
+            ) AS TIMESTAMP){% endif %} as end_time,
         
         -- Check if it's all day event
         CASE 

--- a/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
@@ -83,7 +83,7 @@ extracted AS (
             SELECT COUNT(*) > 0
             FROM UNNEST(JSON_EXTRACT_ARRAY(_raw_record, '$.attendees')) as attendee
             WHERE JSON_EXTRACT_SCALAR(attendee, '$.email') IS NOT NULL
-              AND REGEXP_EXTRACT(JSON_EXTRACT_SCALAR(attendee, '$.email'), {% if target.type == 'bigquery' %}r'@(.+)'{% else %}'@(.+)'{% endif %}) NOT IN (
+              AND {% if target.type == 'bigquery' %}REGEXP_EXTRACT(JSON_EXTRACT_SCALAR(attendee, '$.email'), r'@(.+)'){% else %}regexp_extract(JSON_EXTRACT_SCALAR(attendee, '$.email'), '@(.+)', 1){% endif %} NOT IN (
                   {%- for domain in var('internal_domains', []) -%}
                   '{{ domain }}'
                   {%- if not loop.last -%},{%- endif -%}
@@ -91,7 +91,7 @@ extracted AS (
               )
         ) OR (
             JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email') IS NOT NULL
-            AND REGEXP_EXTRACT(JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email'), {% if target.type == 'bigquery' %}r'@(.+)'{% else %}'@(.+)'{% endif %}) NOT IN (
+            AND {% if target.type == 'bigquery' %}REGEXP_EXTRACT(JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email'), r'@(.+)'){% else %}regexp_extract(JSON_EXTRACT_SCALAR(_raw_record, '$.organizer.email'), '@(.+)', 1){% endif %} NOT IN (
                 {%- for domain in var('internal_domains', []) -%}
                 '{{ domain }}'
                 {%- if not loop.last -%},{%- endif -%}


### PR DESCRIPTION
## Summary

Adds BigQuery support to the cross-adapter macros that previously only had Snowflake + DuckDB branches. Plus duck-side compatibility shims so BigQuery-shaped SQL (\`JSON_EXTRACT_SCALAR\`, \`TO_JSON_STRING\`, \`TIMESTAMP(x)\` etc) compiles + runs on duck without per-call refactoring.

Needed for rolling out the duckdb-local-dev pattern to BigQuery clients — companion to [slide-rule-tech/nexus#343](https://github.com/slide-rule-tech/nexus/pull/343) which applies this to the slide-rule-tech project.

## Cross-adapter macro BQ branches

- **\`try_to_date\` / \`to_date\`** — \`safe.parse_date('<fmt>', col)\` / \`parse_date(...)\` with Snowflake-format → BQ-format translation.
- **\`try_to_timestamp\` / \`to_timestamp\` family** — \`safe.parse_timestamp\` / \`parse_timestamp\` / \`timestamp_micros\` / \`timestamp_seconds\`. BQ has no TIMESTAMP_NTZ distinction; \`_ntz\` variants reuse the base TIMESTAMP form.
- **\`convert_timezone\`** — \`timestamp(datetime(col, '<tz>'), '<tz>')\` pattern (BQ has no \`convert_timezone()\` function).
- **\`interval_cast\`** — \`cast(col AS interval)\` (no precision spec like Snowflake's \`hour(9) to second(0)\`).
- **\`regexp_extract_group\`** — explicit \`r'...'\` raw-string + raises a compile-time error for group_num > 1 (BQ's REGEXP_EXTRACT only returns group 1).
- **\`dedupe\`** — merged the \`snowflake\` and \`bigquery\` branches since both support QUALIFY.

## Duck-side BQ-function shims (\`install_duckdb_compat\`)

Most BigQuery models can compile + run on duck without refactoring thanks to these macro aliases registered at on-run-start:

- Type aliases: \`float64\` → \`DOUBLE\`, \`number\` → \`DECIMAL(38,9)\`.
- JSON: \`json_extract_scalar(col, path)\` → \`json_extract_string\`, \`json_extract_array\` → \`json_extract\`, \`to_json_string\` → \`cast(col AS varchar)\`.
- Date/time: \`timestamp(x)\` → \`cast(x AS timestamp)\`, \`parse_timestamp(fmt, s)\` → \`strptime(s, fmt)\`, \`parse_date(fmt, s)\` → \`cast(strptime(s, fmt) AS date)\`.
- \`safe_cast(col, type)\` → \`try_cast\`. (\`SAFE.CAST\` dotted namespace isn't expressible as a duck macro; refactor those to the underscore form or use \`nexus.try_to_*\` macros.)

## Source meta hooks for gmail / google_calendar

Adds \`meta.external_location\` field to the gmail and google_calendar package source declarations, derived from \`env_var('NEXUS_LOCAL_EXTRACTS')\` + the per-client \`vars.nexus.sources.<source>.schema\`. Lets clients on the duck-dev pattern point those sources at parquet snapshots without a separate yml-override mechanism. No-op on warehouse targets — dbt-snowflake / dbt-bigquery ignore the meta block.

## Compatibility

- Snowflake: zero behavior change (all additions are \`bigquery\` branches; existing \`snowflake\` branches untouched).
- DuckDB: pulls in new shims, no behavior change to existing macros.
- BigQuery: gets full coverage where previously only \`json_path\` worked.

## Test plan

- [ ] Cinch (Snowflake) builds clean on \`--target dev\` (no regression).
- [ ] Cinch (DuckDB) builds clean on \`--target duck\` (no regression).
- [ ] Slide-rule-tech (BigQuery) compiles + runs on \`--target dev\` against the refactored models in slide-rule-tech/nexus#343.
- [ ] Slide-rule-tech (DuckDB) — partial success; ~82 of 234 models build, ~21 still need targeted refactor (see slide-rule-tech/nexus#343 for the remaining-work list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)