### PR TITLE
perf(bq): optional partition + cluster + PK/FK on core nexus_* models

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,61 @@ Or via command line:
 dbt run --vars '{"nexus_schema_dev": "my_custom_schema"}'
 ```
 
+### Warehouse Optimization (BigQuery partition + cluster)
+
+The core `nexus_*` models can be built with BigQuery `partition_by` /
+`cluster_by` configs tuned to the access pattern of typical analytic
+queries (date-windowed event scans + `event_name` / `entity_type` /
+join-key filters). This is **enabled by default on BigQuery** and is
+**off on other adapters**.
+
+| Table | `partition_by` | `cluster_by` |
+|---|---|---|
+| `nexus_events` | `occurred_at` (month) | `event_name, source` |
+| `nexus_event_dimensions` | `occurred_at` (month) | `event_id` |
+| `nexus_event_measurements` | `occurred_at` (month) | `event_id` |
+| `nexus_entity_participants` | `occurred_at` (month) | `entity_type, event_id` |
+| `nexus_entities` | (none) | `entity_type` |
+| `nexus_relationships` | (none) | `relationship_type, entity_a_type, entity_b_type` |
+
+Monthly (not daily) granularity is intentional: real tenant event
+histories commonly exceed BigQuery's 4000-partition cap when sliced
+daily (e.g. 11+ years of Gmail data). Monthly gives ~333 years of
+headroom; a 90-day query still prunes to ~4 monthly partitions ≈
+120 days scanned, negligibly worse than the exact daily scan.
+
+The same toggle also installs **BigQuery informational primary-key
+and foreign-key constraints** (`NOT ENFORCED`) on the core models as
+post-hook `ALTER TABLE` statements. These let the BigQuery query
+optimizer do join elimination and tighter cardinality estimates on
+artifact queries that join the substrate. They cost nothing (no
+storage, no validation) and rely on the constraint actually holding —
+in nexus, PK uniqueness is enforced by `severity: error` dbt tests
+and FK referential integrity is guaranteed by the build graph (every
+dim/measurement/participant row derives from a nexus_events row), so
+the constraints hold by construction.
+
+`nexus_entity_states` and `nexus_entity_state_participants` retain
+their existing pre-set cluster keys.
+
+To override the default (opt out on BigQuery, or opt in on Snowflake):
+
+```yaml
+# In your dbt_project.yml
+vars:
+  nexus:
+    warehouse_optimization:
+      enabled: false   # force off
+      # enabled: true  # force on (Snowflake: applies cluster_by only;
+      #                 partition_by is BigQuery-specific and is a
+      #                 no-op on other adapters)
+```
+
+Auto mode (`enabled` unset or `null`) keeps the on-for-BigQuery /
+off-for-Snowflake default. Snowflake users should be aware that
+clustering on Snowflake triggers paid background reclustering; only
+opt in if you've measured a benefit.
+
 ## Basic Usage
 
 Once installed and configured, you can reference the public models from the

--- a/macros/config/nexus_bq_informational_constraints.sql
+++ b/macros/config/nexus_bq_informational_constraints.sql
@@ -1,0 +1,83 @@
+{% macro nexus_bq_informational_constraints(primary_key=none, foreign_keys=[], external_foreign_keys=[]) %}
+  {# Returns a list of `ALTER TABLE ... NOT ENFORCED` statements suitable
+     for a model's `post_hook=` config. Used to declare BigQuery
+     informational primary-key and foreign-key constraints so the query
+     optimizer can do join elimination and tighter cardinality estimates.
+
+     BigQuery PK/FK constraints are NOT ENFORCED — they're hints, not
+     validations. They're free to add, but if a declared constraint
+     doesn't actually hold the optimizer will return WRONG results.
+     In nexus they hold by construction: PK uniqueness is dbt-tested
+     with severity=error (build halts on violation), and FK referential
+     integrity is guaranteed by the build graph topology (every
+     dim/measurement/participant row is derived from a nexus_events
+     row).
+
+     Usage in a model config:
+       {{ config(
+           materialized='table',
+           post_hook=nexus.nexus_bq_informational_constraints(
+               primary_key='event_id',
+               foreign_keys=[
+                 {'column': 'event_id',
+                  'ref_table': 'nexus_events',
+                  'ref_column': 'event_id'},
+               ],
+           ),
+       ) }}
+
+     Each emitted ALTER TABLE statement contains literal `{{ this }}`
+     Jinja placeholders that dbt re-renders at hook execution time
+     (after the model rebuild). FK targets are constructed lexically
+     from `{{ this.database }}.{{ this.schema }}.<ref_table>` rather
+     than via `ref()` so they don't appear in dbt's compile DAG — the
+     core nexus_* models have real dependency cycles via identity
+     resolution that `ref()` in a post-hook would expose. All core
+     models live in the same dataset by package convention
+     (`nexus_{{ target.name }}`), so the sibling lookup is correct.
+
+     Gated on the same `nexus.warehouse_optimization.enabled` toggle
+     as the partition/cluster macros, and on `target.type == 'bigquery'`.
+     Returns an empty list on Snowflake (post_hook=[] is a clean no-op).
+  #}
+  {%- if not (nexus.nexus_warehouse_optimization_enabled() and target.type == 'bigquery') -%}
+    {%- do return([]) -%}
+  {%- endif -%}
+
+  {%- set statements = [] -%}
+
+  {%- if primary_key -%}
+    {%- do statements.append(
+      'ALTER TABLE {{ this }} ADD PRIMARY KEY (' ~ primary_key ~ ') NOT ENFORCED'
+    ) -%}
+  {%- endif -%}
+
+  {%- for fk in foreign_keys -%}
+    {%- set fk_name = 'fk_' ~ fk.column -%}
+    {%- do statements.append(
+      'ALTER TABLE {{ this }} ADD CONSTRAINT IF NOT EXISTS ' ~ fk_name ~
+      ' FOREIGN KEY (' ~ fk.column ~
+      ') REFERENCES `{{ this.database }}.{{ this.schema }}.' ~ fk.ref_table ~
+      '` (' ~ fk.ref_column ~ ') NOT ENFORCED'
+    ) -%}
+  {%- endfor -%}
+
+  {# External FKs are attached to a *sibling* table — for the
+     participants → entities case where adding the FK from the
+     participants model's post-hook would race with (or cycle with)
+     entities' build. Instead, the model that this hook is attached
+     to (= the FK-referenced model, e.g. nexus_entities) emits an
+     ALTER TABLE on the sibling. By the time this hook runs, the
+     sibling table already exists (it's the parent in the DAG). #}
+  {%- for fk in external_foreign_keys -%}
+    {%- set fk_name = 'fk_' ~ fk.column -%}
+    {%- do statements.append(
+      'ALTER TABLE `{{ this.database }}.{{ this.schema }}.' ~ fk.on_table ~
+      '` ADD CONSTRAINT IF NOT EXISTS ' ~ fk_name ~
+      ' FOREIGN KEY (' ~ fk.column ~ ') REFERENCES {{ this }} (' ~
+      fk.ref_column ~ ') NOT ENFORCED'
+    ) -%}
+  {%- endfor -%}
+
+  {%- do return(statements) -%}
+{% endmacro %}

--- a/macros/config/nexus_bq_partition_by.sql
+++ b/macros/config/nexus_bq_partition_by.sql
@@ -1,0 +1,20 @@
+{% macro nexus_bq_partition_by(field, granularity='day', data_type='timestamp') %}
+  {# Returns a dbt partition_by={...} dict for BigQuery when warehouse
+     optimization is enabled AND the current target is BigQuery.
+     Returns none otherwise — dbt treats partition_by=none as no
+     partitioning, so this is a clean no-op for Snowflake and other
+     adapters.
+
+     Usage in a model config:
+       {{ config(
+           materialized='table',
+           partition_by=nexus.nexus_bq_partition_by('occurred_at'),
+           ...
+       ) }}
+  #}
+  {%- if nexus.nexus_warehouse_optimization_enabled() and target.type == 'bigquery' -%}
+    {%- do return({'field': field, 'data_type': data_type, 'granularity': granularity}) -%}
+  {%- else -%}
+    {%- do return(none) -%}
+  {%- endif -%}
+{% endmacro %}

--- a/macros/config/nexus_cluster_by.sql
+++ b/macros/config/nexus_cluster_by.sql
@@ -1,0 +1,22 @@
+{% macro nexus_cluster_by(keys) %}
+  {# Returns the cluster_by keys list when warehouse optimization is
+     enabled; otherwise none (dbt no-op).
+
+     Works on both BigQuery (free, query-time block pruning) and
+     Snowflake (paid auto-clustering). Default-off on Snowflake via
+     nexus_warehouse_optimization_enabled — a Snowflake operator must
+     explicitly opt in.
+
+     Usage:
+       {{ config(
+           materialized='table',
+           cluster_by=nexus.nexus_cluster_by(['event_name', 'source']),
+           ...
+       ) }}
+  #}
+  {%- if nexus.nexus_warehouse_optimization_enabled() -%}
+    {%- do return(keys) -%}
+  {%- else -%}
+    {%- do return(none) -%}
+  {%- endif -%}
+{% endmacro %}

--- a/macros/config/nexus_warehouse_optimization_enabled.sql
+++ b/macros/config/nexus_warehouse_optimization_enabled.sql
@@ -1,0 +1,26 @@
+{% macro nexus_warehouse_optimization_enabled() %}
+  {# Returns true when the warehouse-optimization toggles (partition_by,
+     cluster_by on the core nexus_* models) should be applied.
+
+     Controlled by:
+       vars:
+         nexus:
+           warehouse_optimization:
+             enabled: null | true | false
+
+     - null / unset: auto mode — on for BigQuery only. Snowflake gets
+       no-ops because Snowflake clustering is billed background work
+       and we don't want to enable it by default.
+     - true: force on. A Snowflake user opting in here gets cluster_by
+       on the core models (no partition_by, which is BQ-specific and
+       returns none on Snowflake anyway).
+     - false: force off. A BigQuery user opts out here.
+  #}
+  {%- set cfg = var('nexus', {}).get('warehouse_optimization', {}) -%}
+  {%- set explicit = cfg.get('enabled') -%}
+  {%- if explicit is not none -%}
+    {%- do return(explicit) -%}
+  {%- else -%}
+    {%- do return(target.type == 'bigquery') -%}
+  {%- endif -%}
+{% endmacro %}

--- a/models/core/nexus.yml
+++ b/models/core/nexus.yml
@@ -294,15 +294,68 @@ models:
       "Pivoted entity states table with one column per state name.
       One row per state change with valid_from/valid_to temporal bounds."
 
+  - name: nexus_event_dimensions
+    description:
+      "Pivoted event dimensions table with one column per dimension name.
+      One row per event. Dimension columns are discovered dynamically at
+      compile time from nexus_event_dimensions_unioned."
+    tests:
+      # event_id is declared as a BigQuery informational PRIMARY KEY in this
+      # model's config (nexus_bq_informational_constraints). That constraint is
+      # NOT ENFORCED, so the optimizer trusts it for join elimination — this
+      # error-severity uniqueness test is what makes that trust safe.
+      - unique:
+          column_name: event_id
+          config:
+            severity: error
+    columns:
+      - name: event_id
+        description: "Reference to the source event; one row per event (primary key)"
+        tests:
+          - not_null:
+              config:
+                severity: error
+
   - name: nexus_event_measurements
     description:
       "Pivoted event measurements table with one column per measurement name.
       One row per event. Measurement columns are discovered dynamically at
       compile time from nexus_event_measurements_unioned."
+    tests:
+      # See nexus_event_dimensions: event_id is a NOT ENFORCED informational PK,
+      # so its uniqueness must be guarded by an error-severity test.
+      - unique:
+          column_name: event_id
+          config:
+            severity: error
+    columns:
+      - name: event_id
+        description: "Reference to the source event; one row per event (primary key)"
+        tests:
+          - not_null:
+              config:
+                severity: error
 
   - name: nexus_entity_participants
     description:
       "Maps events to resolved entities, enabling entity-level event queries"
+    tests:
+      # entity_participant_id is a NOT ENFORCED informational PK. Its uniqueness
+      # currently holds only because occurred_at is functionally determined by
+      # event_id (the id hashes event_id+entity_id+role, the SQL groups by those
+      # plus occurred_at). This error-severity test guards that invariant so the
+      # optimizer never does join elimination on a PK that has silently drifted.
+      - unique:
+          column_name: entity_participant_id
+          config:
+            severity: error
+    columns:
+      - name: entity_participant_id
+        description: "Unique identifier for the event-to-entity participation (primary key)"
+        tests:
+          - not_null:
+              config:
+                severity: error
 
   - name: nexus_attribution_model_results
     description:

--- a/models/core/nexus_entities.sql
+++ b/models/core/nexus_entities.sql
@@ -1,4 +1,24 @@
-{{ config(materialized='table', tags=['identity-resolution', 'entities']) }}
+{{ config(
+    materialized='table',
+    cluster_by=nexus.nexus_cluster_by(['entity_type']),
+    post_hook=nexus.nexus_bq_informational_constraints(
+        primary_key='entity_id',
+        external_foreign_keys=[
+            {'on_table': 'nexus_entity_participants',
+             'column': 'entity_id',
+             'ref_column': 'entity_id'},
+        ],
+    ),
+    tags=['identity-resolution', 'entities']
+) }}
+
+{# The external_foreign_keys entry above attaches the
+   `nexus_entity_participants.entity_id → nexus_entities.entity_id`
+   FK from THIS model's post_hook, not participants'. Reason:
+   nexus_entities transitively depends on nexus_entity_participants
+   via identity resolution, so a `depends_on` from participants to
+   entities would cycle the build graph. By the time this post_hook
+   runs, participants already exists. #}
 
 -- depends_on: {{ ref('nexus_computed_traits') }}
 

--- a/models/core/nexus_entity_participants.sql
+++ b/models/core/nexus_entity_participants.sql
@@ -1,4 +1,33 @@
-{{ config(materialized='table', tags=['identity-resolution', 'participants', 'realtime']) }}
+{{ config(
+    materialized='table',
+    partition_by=nexus.nexus_bq_partition_by('occurred_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_type', 'event_id']),
+    post_hook=nexus.nexus_bq_informational_constraints(
+        primary_key='entity_participant_id',
+        foreign_keys=[
+            {'column': 'event_id', 'ref_table': 'nexus_events', 'ref_column': 'event_id'},
+        ],
+    ),
+    tags=['identity-resolution', 'participants', 'realtime']
+) }}
+
+{# Monthly (not daily) partitioning on occurred_at: participant data
+   inherits timestamps from every event source the package unions in
+   (Gmail history, calendar history, etc.) and routinely spans more
+   than the 4000-partition BigQuery cap when partitioned daily.
+   Monthly granularity gives 4000 / 12 ≈ 333 years of headroom and
+   still gives downstream queries a ~4-partition prune on a 90-day
+   window.
+
+   The FK on entity_id → nexus_entities is intentionally NOT declared
+   here; it's attached by nexus_entities' post_hook (as an
+   external_foreign_keys entry), because nexus_entities transitively
+   depends on this model via identity resolution and a `depends_on`
+   from here to entities would cycle the build graph. #}
+
+-- depends_on: {{ ref('nexus_events') }}
+-- ^ ensures nexus_events finishes (PK constraint added by its post_hook)
+--   before this model's FK to nexus_events.event_id is added.
 
 {% set er_types = nexus.get_er_entity_types() %}
 {% set non_er_types = nexus.get_non_er_entity_types() %}

--- a/models/core/nexus_event_dimensions.sql
+++ b/models/core/nexus_event_dimensions.sql
@@ -1,7 +1,22 @@
 {{ config(
     materialized='table',
+    partition_by=nexus.nexus_bq_partition_by('occurred_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_id']),
+    post_hook=nexus.nexus_bq_informational_constraints(
+        primary_key='event_id',
+        foreign_keys=[
+            {'column': 'event_id', 'ref_table': 'nexus_events', 'ref_column': 'event_id'},
+        ],
+    ),
     tags=['dimensions']
 ) }}
+
+{# Monthly partition: see nexus_events for rationale — event-derived
+   tables routinely exceed the 4000 daily-partition cap. #}
+
+-- depends_on: {{ ref('nexus_events') }}
+-- ^ ensures nexus_events finishes (PK constraint added by its post_hook)
+--   before this model's FK to nexus_events.event_id is added.
 
 -- Nexus Event Dimensions (Core)
 -- Pivots nexus_event_dimensions_unioned into a wide table with one column per dimension.

--- a/models/core/nexus_event_measurements.sql
+++ b/models/core/nexus_event_measurements.sql
@@ -1,7 +1,22 @@
 {{ config(
     materialized='table',
+    partition_by=nexus.nexus_bq_partition_by('occurred_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_id']),
+    post_hook=nexus.nexus_bq_informational_constraints(
+        primary_key='event_id',
+        foreign_keys=[
+            {'column': 'event_id', 'ref_table': 'nexus_events', 'ref_column': 'event_id'},
+        ],
+    ),
     tags=['measurements']
 ) }}
+
+{# Monthly partition: see nexus_events for rationale — event-derived
+   tables routinely exceed the 4000 daily-partition cap. #}
+
+-- depends_on: {{ ref('nexus_events') }}
+-- ^ ensures nexus_events finishes (PK constraint added by its post_hook)
+--   before this model's FK to nexus_events.event_id is added.
 
 -- Nexus Event Measurements (Core)
 -- Pivots nexus_event_measurements_unioned into a wide table with one column per measurement.

--- a/models/core/nexus_events.sql
+++ b/models/core/nexus_events.sql
@@ -1,4 +1,16 @@
-{{ config(materialized = 'table')}}
+{{ config(
+    materialized='table',
+    partition_by=nexus.nexus_bq_partition_by('occurred_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_name', 'source']),
+    post_hook=nexus.nexus_bq_informational_constraints(primary_key='event_id'),
+) }}
+
+{# Monthly (not daily) partitioning on occurred_at: event history in
+   real tenants commonly spans more than the 4000-partition BigQuery
+   cap when partitioned daily (e.g. AWM exceeds 4000 days). Monthly
+   gives 4000 / 12 ≈ 333 years of headroom; a 90-day query still
+   prunes to ~4 monthly partitions ≈ 120 days scanned, negligibly
+   worse than the 90-day exact scan daily would give. #}
 
 {# Collect relations to union based on sources with events #}
 {% set relations_to_union = [] %}
@@ -127,5 +139,12 @@ SELECT
     {% endfor %}
     {{ processed_columns | join(',\n    ') }},
     current_timestamp() as _processed_at
-FROM unioned 
+FROM unioned
+{# BigQuery rejects `ORDER BY` in a CTAS that uses `partition_by`.
+   The ORDER BY at write time was never load-bearing for downstream
+   consumers — BigQuery and Snowflake both re-sort at read time when
+   needed — so we drop it whenever partitioning is on. Without
+   partitioning, preserve the historical ordering hint. #}
+{% if not (nexus.nexus_warehouse_optimization_enabled() and target.type == 'bigquery') %}
 ORDER BY occurred_at DESC
+{% endif %}

--- a/models/core/nexus_relationships.sql
+++ b/models/core/nexus_relationships.sql
@@ -1,4 +1,19 @@
-{{ config(materialized='table', tags=['identity-resolution', 'relationships']) }}
+{{ config(
+    materialized='table',
+    cluster_by=nexus.nexus_cluster_by(['relationship_type', 'entity_a_type', 'entity_b_type']),
+    post_hook=nexus.nexus_bq_informational_constraints(
+        primary_key='relationship_id',
+        foreign_keys=[
+            {'column': 'entity_a_id', 'ref_table': 'nexus_entities', 'ref_column': 'entity_id'},
+            {'column': 'entity_b_id', 'ref_table': 'nexus_entities', 'ref_column': 'entity_id'},
+        ],
+    ),
+    tags=['identity-resolution', 'relationships']
+) }}
+
+-- depends_on: {{ ref('nexus_entities') }}
+-- ^ ensures nexus_entities finishes (PK constraint added by its post_hook)
+--   before this model's FKs to nexus_entities.entity_id are added.
 
 {{ nexus.finalize_relationships() }}
 


### PR DESCRIPTION
## Summary

Three opt-out BigQuery optimizations to the six core canonical models, gated behind a single `nexus.warehouse_optimization.enabled` toggle (default on for BigQuery, off elsewhere; Snowflake gets a clean no-op):

1. **Monthly `partition_by` on `occurred_at`** for `nexus_events`, `nexus_event_dimensions`, `nexus_event_measurements`, `nexus_entity_participants`. Verified ~10× scan reduction on AWM dev (3.2 MB filtered vs 34 MB full scan on a 90-day window).
2. **`cluster_by`** keys tuned to the actual filter corpus across 71 production artifacts:

   | Table | `cluster_by` |
   |---|---|
   | `nexus_events` | `event_name, source` |
   | `nexus_event_dimensions` / `nexus_event_measurements` | `event_id` |
   | `nexus_entity_participants` | `entity_type, event_id` |
   | `nexus_entities` | `entity_type` |
   | `nexus_relationships` | `relationship_type, entity_a_type, entity_b_type` |
3. **Informational `PRIMARY KEY` + `FOREIGN KEY` constraints (`NOT ENFORCED`)** as post-hook `ALTER TABLE`s. Enables BigQuery's join-elimination and tighter cardinality estimates. Safety net via `severity: error` `unique` tests on the new PK columns (`nexus_events` and `nexus_entities` already had them; this PR adds the missing ones on `nexus_event_dimensions`, `nexus_event_measurements`, `nexus_entity_participants`).

## Why these specific keys?

A grep across all 71 production artifacts showed a tightly uniform access pattern: 173+ `occurred_at >=` predicates, 158+ `occurred_at <`, `event_name='enrollment'` 61×, `entity_type='person'` 120×, `relationship_type='advisor'` 19×, joins on `event_id` 110×+, etc. Keys are chosen from that real distribution, not guesses.

## Monthly (not daily) granularity

Real tenant event histories routinely exceed BigQuery's 4000 daily-partition cap (e.g. AWM has >11 years of data — daily fails the CTAS). Monthly gives ~333 years of headroom while still pruning a 90-day query to ~4 partitions ≈ 120 days scanned (vs the perfect 90 daily would give). Negligible difference; safer rollout.

## Opt-out / opt-in

```yaml
# In a client's dbt_project.yml
vars:
  nexus:
    warehouse_optimization:
      enabled: false   # BigQuery user opts out
      # enabled: true  # Snowflake user opts in (adds billed cluster_by;
      #                # partition_by is BigQuery-specific and no-op)
```

Unset (or `null`) = auto: on for BigQuery, off elsewhere.

## Verification

Built end-to-end against AWM dev (`austin-wealth-management.development`):
- All 6 models build clean in 37–76s, topologically ordered (events → dimensions/measurements/participants → entities → relationships).
- `INFORMATION_SCHEMA.PARTITIONS`, `INFORMATION_SCHEMA.COLUMNS`, `INFORMATION_SCHEMA.TABLE_CONSTRAINTS`, `INFORMATION_SCHEMA.KEY_COLUMN_USAGE` all confirm the expected partition / cluster / PK / FK metadata.
- Opt-out toggle confirmed: setting `enabled: false` in `dbt_project.yml` produces zero partitions/clusters in the manifest.
- Join elimination measured: `LEFT JOIN nexus_event_dimensions ON event_id = event_id` where no dim columns are selected scans **exactly the baseline bytes** of `nexus_events` alone — BQ's optimizer drops the join entirely using the new PK/FK constraints.

## Implementation notes

- New macros under `macros/config/`: `nexus_warehouse_optimization_enabled`, `nexus_bq_partition_by`, `nexus_cluster_by`, `nexus_bq_informational_constraints`. All return `none`/`[]` on Snowflake or when the toggle is off, so configs gracefully no-op.
- The `participants → entities` FK is attached from `nexus_entities`' post-hook (as an `external_foreign_keys` entry) rather than `participants` because `entities` transitively depends on `participants` via identity resolution — a normal `ref()`-style FK there would cycle the build graph.
- FK targets are constructed lexically from `{{ this.database }}.{{ this.schema }}.<ref_table>` instead of `ref()` so the constraint creation doesn't add edges to dbt's compile DAG. All core models live in the same dataset by package convention.

## Test plan

- [x] All six core models rebuild clean against a real BigQuery client (AWM)
- [x] Constraints visible in `INFORMATION_SCHEMA.TABLE_CONSTRAINTS` + `KEY_COLUMN_USAGE`
- [x] Partition / cluster metadata visible in `INFORMATION_SCHEMA.PARTITIONS` + `COLUMNS`
- [x] `vars.nexus.warehouse_optimization.enabled: false` produces partition=None, cluster=None
- [x] Join elimination verified live (LEFT JOIN with no right cols selected scans baseline-only bytes)
- [ ] Snowflake build still clean (defaults to off; gameday/go-koala will pick this up at next release tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)