### PR TITLE
fix: BigQuery VARCHAR cast + duplicate entity_participant_id (gmail group ids)

### DIFF
--- a/models/sources/gmail/intermediate/gmail_message_group_identifiers.sql
+++ b/models/sources/gmail/intermediate/gmail_message_group_identifiers.sql
@@ -25,7 +25,14 @@ domains_filtered AS (
 -- Create domain identifiers
 domain_identifiers AS (
     SELECT
-        {{ nexus.create_nexus_id('entity_identifier', ['event_id', 'domain', "'group'", 'role', 'sent_at']) }} as entity_identifier_id,
+        -- occurred_at (sent_at) is deliberately NOT part of the id. It's a
+        -- property of the event, and one logical event (event_id =
+        -- hash(message_id)) can arrive from several synced mailboxes with
+        -- slightly different sent_at; keying the id on it gave each copy a
+        -- distinct id, so the dedup below couldn't collapse them and downstream
+        -- entity_participant_id (hash of event_id+entity_id+role) duplicated.
+        -- Keyed on the same components as edge_id and the person identifiers.
+        {{ nexus.create_nexus_id('entity_identifier', ['event_id', 'domain', "'group'", 'role']) }} as entity_identifier_id,
         event_id,
         {{ nexus.create_nexus_id('edge', ['event_id', 'domain', "'group'", 'role']) }} as edge_id,
         'group' as entity_type,
@@ -42,7 +49,7 @@ domain_identifiers AS (
 -- Add redirected domains (www. versions)
 redirected_domains AS (
     SELECT
-        {{ nexus.create_nexus_id('entity_identifier', ['event_id', nexus.redirected_domain('domain'), "'group'", 'role', 'sent_at']) }} as entity_identifier_id,
+        {{ nexus.create_nexus_id('entity_identifier', ['event_id', nexus.redirected_domain('domain'), "'group'", 'role']) }} as entity_identifier_id,
         event_id,
         {{ nexus.create_nexus_id('edge', ['event_id', nexus.redirected_domain('domain'), "'group'", 'role']) }} as edge_id,
         'group' as entity_type,

--- a/models/sources/gmail/intermediate/gmail_thread_group_identifiers.sql
+++ b/models/sources/gmail/intermediate/gmail_thread_group_identifiers.sql
@@ -39,7 +39,14 @@ domains_with_roles AS (
 -- Create domain identifiers
 domain_identifiers AS (
     SELECT
-        {{ nexus.create_nexus_id('entity_identifier', ['event_id', 'domain', "'group'", 'role', 'first_participated_at']) }} as entity_identifier_id,
+        -- occurred_at (first_participated_at) is deliberately NOT part of the id.
+        -- It's a property of the event, and one logical event (event_id =
+        -- hash(thread_id)) can arrive from several synced mailboxes with slightly
+        -- different timestamps; keying the id on it gave each copy a distinct id,
+        -- so the dedup below couldn't collapse them and downstream
+        -- entity_participant_id (hash of event_id+entity_id+role) duplicated.
+        -- Keyed on the same components as edge_id and the person identifiers.
+        {{ nexus.create_nexus_id('entity_identifier', ['event_id', 'domain', "'group'", 'role']) }} as entity_identifier_id,
         event_id,
         {{ nexus.create_nexus_id('edge', ['event_id', 'domain', "'group'", 'role']) }} as edge_id,
         'group' as entity_type,
@@ -56,7 +63,7 @@ domain_identifiers AS (
 -- Add redirected domains (www. versions)
 redirected_domains AS (
     SELECT
-        {{ nexus.create_nexus_id('entity_identifier', ['event_id', nexus.redirected_domain('domain'), "'group'", 'role', 'first_participated_at']) }} as entity_identifier_id,
+        {{ nexus.create_nexus_id('entity_identifier', ['event_id', nexus.redirected_domain('domain'), "'group'", 'role']) }} as entity_identifier_id,
         event_id,
         {{ nexus.create_nexus_id('edge', ['event_id', nexus.redirected_domain('domain'), "'group'", 'role']) }} as edge_id,
         'group' as entity_type,

--- a/models/sources/google_calendar/base/google_calendar_events_base_dedupped.sql
+++ b/models/sources/google_calendar/base/google_calendar_events_base_dedupped.sql
@@ -37,7 +37,7 @@ with_event_key AS (
     SELECT
         *,
         CASE
-            WHEN is_recurring THEN CONCAT(ical_uid, '|', CAST(instance_start AS VARCHAR))
+            WHEN is_recurring THEN CONCAT(ical_uid, '|', CAST(instance_start AS {% if target.type == 'bigquery' %}STRING{% else %}VARCHAR{% endif %}))
             ELSE ical_uid
         END AS event_key
     FROM source_data

--- a/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
@@ -124,7 +124,7 @@ with_composite_key AS (
         -- Use iCalUID as primary key for single events
         -- Use iCalUID + instanceStart for recurring events
         CASE 
-            WHEN is_recurring THEN CONCAT(ical_uid, '|', CAST(instance_start AS VARCHAR))
+            WHEN is_recurring THEN CONCAT(ical_uid, '|', CAST(instance_start AS {% if target.type == 'bigquery' %}STRING{% else %}VARCHAR{% endif %}))
             ELSE ical_uid
         END as event_key
     FROM extracted


### PR DESCRIPTION
Two BigQuery build failures that surface, one behind the other, when a client adopts **v0.11.5**. Verified by full `dbt build --target dev` on **austin-wealth** and **slide-rule-tech**.

## 1. `Type not found: VARCHAR` (google_calendar)

The recurring-event branch of the `event_key` derivation cast `instance_start` with `CAST(... AS VARCHAR)`. `VARCHAR` isn't a BigQuery type, so `google_calendar_events_base_dedupped` errors at planning and the **entire downstream graph is skipped**. Same unguarded cast in the normalized model.

**Fix:** gate the cast with the file's existing `target.type == 'bigquery'` convention (`STRING` on BigQuery, `VARCHAR` elsewhere).
- `models/sources/google_calendar/base/google_calendar_events_base_dedupped.sql`
- `models/sources/google_calendar/normalized/google_calendar_events_normalized.sql`

## 2. Duplicate `entity_participant_id` (gmail group identifiers)

With google_calendar fixed, the build reached the **new error-severity `unique` test** on `nexus_entity_participants.entity_participant_id` (added in v0.11.5 to back the unenforced informational PRIMARY KEY) — and it failed (29,314 dup ids on austin-wealth, 9,496 on slide-rule-tech).

**Root cause:** the domain/group `entity_identifier_id` in `gmail_message_group_identifiers` and `gmail_thread_group_identifiers` keyed on the event timestamp (`sent_at` / `first_participated_at`), while `edge_id` and the person identifiers did not. `event_id` already hashes `message_id`/`thread_id`, so one logical event arriving from several synced mailboxes (slightly different timestamps) got a *distinct* identifier id per copy → the `PARTITION BY entity_identifier_id` dedup couldn't collapse them → multiple `occurred_at` flowed into `finalize_participants` (which groups by `occurred_at`) → multiple participant rows hashing to the same `entity_participant_id`.

**Fix:** drop the timestamp from both group identifier ids so they match `edge_id` and the person identifiers; the existing `_ingested_at` dedup then keeps one row per `(event_id, domain, role)`.
- `models/sources/gmail/intermediate/gmail_message_group_identifiers.sql`
- `models/sources/gmail/intermediate/gmail_thread_group_identifiers.sql`

**Verified:** `unique_nexus_entity_participants_entity_participant_id` now passes on both clients (austin-wealth: 11,207,770 rows, 0 dup ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)