### PR TITLE
Bump gmail/calendar significance + fix calendar column name

### DIFF
--- a/models/sources/gmail/intermediate/gmail_message_events.sql
+++ b/models/sources/gmail/intermediate/gmail_message_events.sql
@@ -13,7 +13,7 @@ SELECT
     subject as event_description,
     CASE
         WHEN COALESCE(is_automated_or_bulk_message, FALSE) THEN -10
-        ELSE 0
+        ELSE 10
     END as significance,
     'gmail' as source,
     'gmail_message_events' as source_table,

--- a/models/sources/google_calendar/intermediate/google_calendar_event_events.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_event_events.sql
@@ -13,10 +13,10 @@ SELECT
         ELSE 'internal_meeting'
     END as event_name,
     COALESCE(summary, 'Calendar Event') as event_description,
-    CASE 
-        WHEN has_external_attendees THEN 3
-        ELSE 2
-    END as event_significance,
+    -- `event_significance` was a typo: nexus_events selects the column `significance`,
+    -- so calendar rows had NULL significance downstream. Renamed to `significance`
+    -- and bumped to 100 — calendar meetings are the highest-signal engagement.
+    100 as significance,
     'calendar_event' as event_type,
     source,
     _ingested_at,


### PR DESCRIPTION
## Summary
- **google_calendar_event_events**: rename `event_significance` → `significance` and set to `100`. The old name didn't match what `nexus_events` selects on (it selects `significance`), so every calendar row landed in `nexus_events` with a NULL significance. Renaming fixes that and bumps the value to 100 — calendar meetings are the highest-signal engagement.
- **gmail_message_events**: bump non-bulk/non-automated email significance from `0` → `10`. Bulk/automated stays at `-10`.

## Why
Downstream tools (e.g. the AWM event timeline) want a single numeric `significance` column they can use as a signal-vs-noise threshold. Today calendar rows have NULL significance (silent typo) and non-bulk gmail is indistinguishable from "no opinion" (`0`). After this change, a `significance >= 1` filter cleanly keeps meetings + meaningful email + anything else explicitly positive, while a `>= 0` (or COALESCE-with-null-kept) filter keeps everything that hasn't been explicitly downweighted.

## Test plan
- [ ] Run `dbt build --select google_calendar_event_events+ gmail_message_events+` against a tenant with both sources enabled; verify `nexus_events.significance` is populated (100 for calendar, 10 / -10 for gmail).
- [ ] Confirm no other models reference `event_significance` (this column was unused downstream — that's why the typo was invisible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)