### PR TITLE
feat(tracking-plans): nexus_tracking_plans + nexus_tracking_plan_calls metadata models

### DIFF
--- a/models/sources/tracking_plans/base/base_tracking_plans.sql
+++ b/models/sources/tracking_plans/base/base_tracking_plans.sql
@@ -1,0 +1,10 @@
+{{ config(
+    enabled=var('nexus', {}).get('sources', {}).get('tracking_plans', {}).get('enabled', false),
+    materialized='view',
+    tags=['nexus', 'tracking_plans', 'base']
+) }}
+
+-- Passthrough of the raw `tracking_plans` BBP collection. Gated by
+-- var('nexus').sources.tracking_plans.enabled so it's a no-op for clients that
+-- don't have a tracking plan projected.
+select * from {{ source('tracking_plans', 'tracking_plans') }}

--- a/models/sources/tracking_plans/nexus_tracking_plan_calls.sql
+++ b/models/sources/tracking_plans/nexus_tracking_plan_calls.sql
@@ -1,0 +1,45 @@
+{{ config(
+    enabled=var('nexus', {}).get('sources', {}).get('tracking_plans', {}).get('enabled', false),
+    materialized='table',
+    tags=['nexus', 'tracking_plans', 'metadata']
+) }}
+
+-- Nexus Tracking Plan Calls — one row per documented CALL (event) in the current
+-- tracking plan, per (organization_id, plan_slug). Flattens `plan.calls[]` from
+-- nexus_tracking_plans. This is the queryable catalog of DOCUMENTED events — the
+-- basis for the (deferred) documented-vs-fired FULL OUTER JOIN against
+-- nexus_events. Warehouse-portable (Snowflake LATERAL FLATTEN vs BigQuery UNNEST).
+
+with plans as (
+    select * from {{ ref('nexus_tracking_plans') }}
+)
+
+{% if target.type == 'bigquery' %}
+select
+    plans.organization_id,
+    plans.plan_slug,
+    plans.content_hash,
+    plans.last_updated_at,
+    json_value(c, '$.slug') as call_slug,
+    json_value(c, '$.name') as call_name,
+    json_value(c, '$.fires_on') as fires_on,
+    json_value(c, '$.kind') as kind,
+    cast(json_value(c, '$.is_conversion') as bool) as is_conversion,
+    json_value(c, '$.source') as source,
+    json_value(c, '$.segment_source') as segment_source
+from plans, unnest(json_query_array(plans.plan, '$.calls')) as c
+{% else %}
+select
+    plans.organization_id,
+    plans.plan_slug,
+    plans.content_hash,
+    plans.last_updated_at,
+    c.value:slug::string as call_slug,
+    c.value:name::string as call_name,
+    c.value:fires_on::string as fires_on,
+    c.value:kind::string as kind,
+    c.value:is_conversion::boolean as is_conversion,
+    c.value:source::string as source,
+    c.value:segment_source::string as segment_source
+from plans, lateral flatten(input => plans.plan:calls) c
+{% endif %}

--- a/models/sources/tracking_plans/nexus_tracking_plans.sql
+++ b/models/sources/tracking_plans/nexus_tracking_plans.sql
@@ -1,0 +1,81 @@
+{{ config(
+    enabled=var('nexus', {}).get('sources', {}).get('tracking_plans', {}).get('enabled', false),
+    materialized='table',
+    tags=['nexus', 'tracking_plans', 'metadata']
+) }}
+
+-- Nexus Tracking Plans — one row per (organization_id, plan_slug): the CURRENT
+-- (latest-landed) version of the file-defined tracking plan, plus a small
+-- summary + the raw plan payload. The collection is append-only (a row per
+-- plan version), so we dedup latest-per-key by `_ingested_at`. Warehouse-portable
+-- (Snowflake VARIANT vs BigQuery JSON).
+
+with base as (
+    select * from {{ ref('base_tracking_plans') }}
+),
+
+extracted as (
+    select
+        {% if target.type == 'bigquery' %}
+        json_value(_raw_record, '$.organization_id') as organization_id,
+        json_value(_raw_record, '$.plan_slug') as plan_slug,
+        json_value(_raw_record, '$.content_hash') as content_hash,
+        json_query(_raw_record, '$.plan') as plan,
+        array_length(json_query_array(_raw_record, '$.plan.calls')) as num_calls,
+        array_length(json_query_array(_raw_record, '$.plan.properties')) as num_properties,
+        array_length(json_query_array(_raw_record, '$.plan.event_properties')) as num_event_properties,
+        {% else %}
+        _raw_record:organization_id::string as organization_id,
+        _raw_record:plan_slug::string as plan_slug,
+        _raw_record:content_hash::string as content_hash,
+        _raw_record:plan as plan,
+        array_size(_raw_record:plan:calls) as num_calls,
+        array_size(_raw_record:plan:properties) as num_properties,
+        array_size(_raw_record:plan:event_properties) as num_event_properties,
+        {% endif %}
+        _producer,
+        _row_id,
+        _queued_at,
+        _ingested_at
+    from base
+),
+
+-- Version history stats per plan (across all landed rows, before dedup).
+stats as (
+    select
+        organization_id,
+        plan_slug,
+        min(_ingested_at) as first_seen_at,
+        count(*) as version_rows
+    from extracted
+    where plan_slug is not null
+    group by organization_id, plan_slug
+),
+
+-- The current version: latest row per (organization_id, plan_slug).
+latest as (
+    select *
+    from extracted
+    where plan_slug is not null
+    qualify row_number() over (
+        partition by organization_id, plan_slug
+        order by _ingested_at desc, _row_id desc
+    ) = 1
+)
+
+select
+    latest.organization_id,
+    latest.plan_slug,
+    latest.content_hash,
+    latest.num_calls,
+    latest.num_properties,
+    latest.num_event_properties,
+    latest.plan,
+    latest._producer as producer,
+    stats.first_seen_at,
+    latest._ingested_at as last_updated_at,
+    stats.version_rows
+from latest
+join stats
+    on stats.organization_id = latest.organization_id
+    and stats.plan_slug = latest.plan_slug

--- a/models/sources/tracking_plans/tracking_plans.yml
+++ b/models/sources/tracking_plans/tracking_plans.yml
@@ -1,0 +1,31 @@
+version: 2
+
+sources:
+  - name: tracking_plans
+    description: >
+      Tracking plans — the "Big Beautiful Pipeline" `tracking_plans` collection.
+      A file-defined tracking plan (source of truth = a `.ts` file on the Nexus
+      master branch) projected to each client's warehouse on the BBP contract:
+      the lean envelope columns (`_convex_id`, `_row_id`, `_queued_at`,
+      `_ingested_at`, `_schema_id`, `_producer`, `_actor`) plus a `_raw_record`
+      JSON/VARIANT payload `{organization_id, plan_slug, content_hash, plan}`,
+      where `plan` nests `calls[] / properties[] / event_properties[] /
+      organization`. Append-only + change-gated: one row per plan VERSION, so
+      latest-per-(organization_id, plan_slug) is the current plan.
+    schema: >-
+      {{ var('nexus', {}).get('sources', {}).get('tracking_plans', {}).get('schema',
+      'tracking_plans_disabled_' ~ project_name) }}
+    database: >-
+      {{ var('nexus', {}).get('sources', {}).get('tracking_plans', {}).get('database', '') }}
+    tables:
+      - name: tracking_plans
+        identifier: >-
+          {{ var('nexus', {}).get('sources', {}).get('tracking_plans', {}).get('table', 'tracking_plans') }}
+        description: "Raw tracking_plans collection rows (append-only version log)."
+        columns:
+          - name: _raw_record
+            description: "JSON/VARIANT payload: {organization_id, plan_slug, content_hash, plan{calls,properties,event_properties,organization}}."
+          - name: _ingested_at
+            description: "When this plan version landed (latest wins per org+plan)."
+          - name: _producer
+            description: "Envelope producer (e.g. 'tracking-plans')."


### PR DESCRIPTION
Adds dbt-nexus models that read the **BBP `tracking_plans` collection** (a file-defined tracking plan projected to each client's warehouse) into canonical metadata — the phase-2 consumer for the BBP-for-files tracking-plan editor.

**New `models/sources/tracking_plans/`:**
- `tracking_plans.yml` — source (schema/database/table via `var('nexus').sources.tracking_plans`, enabled-gated)
- `base_tracking_plans.sql` — raw passthrough
- **`nexus_tracking_plans.sql`** — one row per (org, plan): latest version, counts, `content_hash`, raw `plan`, first/last timestamps, version count
- **`nexus_tracking_plan_calls.sql`** — one row per documented event (the catalog; basis for the future documented-vs-fired join against `nexus_events`)

Warehouse-portable (Snowflake VARIANT + BigQuery JSON branches). Disabled by default; a client opts in via `vars.nexus.sources.tracking_plans: {enabled, schema, database}`.

**Verified on a24-films:** `dbt build` → `nexus_tracking_plans` (1 row: 44 calls / 114 props / 1924 event-props) + `nexus_tracking_plan_calls` (44 rows) against `DEV_KEVIN.os_nexus_development`. PASS=3.

Ship: merge → tag **v0.11.10** (patch bump from v0.11.9); a24-dbt then bumps to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)