### PR TITLE
Incremental identity resolution via graph contraction (flag-gated, experimental)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -41,6 +41,10 @@ vars:
   # Nexus source configuration
 
   nexus:
+    # Incremental identity resolution (experimental, default off).
+    # See docs/incremental-identity-resolution.md before enabling.
+    incremental:
+      enabled: false
     max_recursion: 5
     edge_quality:
       critical_threshold: 50

--- a/docs/incremental-identity-resolution.md
+++ b/docs/incremental-identity-resolution.md
@@ -1,0 +1,418 @@
+# Incremental Identity Resolution
+
+**Status:** experimental, flag-gated (`nexus.incremental.enabled`, default
+`false`). With the flag off, every model behaves exactly as before.
+
+This document is both the design rationale and the spec. It exists because
+incremental entity resolution is not just a materialization change — it
+changes what an entity id *is* — and future contributors need the reasoning,
+not just the code.
+
+---
+
+## 1. Motivation
+
+Every dbt-nexus run today rebuilds the entire pipeline from scratch: every
+event, every identifier, every edge, and a full connected-components traversal
+over the whole identity graph. Cost and wall-clock scale with total history,
+not with what changed. The blocker to incrementality was identity resolution:
+a new event can create a brand-new entity, attach identifiers to an existing
+entity, or merge two previously separate entities — and naïve incremental
+models can't express "merge."
+
+## 2. Conceptual foundations
+
+### 2.1 Full refresh and incremental are different ontologies
+
+A full-refresh pipeline treats the entity graph as a **pure function of
+history**: identity is memoryless, everything can be rederived. An incremental
+pipeline treats it as **state that evolves**: entities are born, accrete
+identifiers, and merge. Identity acquires a biography.
+
+That difference surfaces as a small impossibility result: an id can be
+**content-deterministic** (any two people resolving the same full history get
+identical ids — the current hash-of-lexicographically-min-identifier scheme)
+or **prefix-stable** (ids never churn as data arrives), but not both. A label
+that is stable from birth cannot be a deterministic function of a final set
+you haven't seen yet.
+
+Incremental mode picks prefix-stability. Consequences:
+
+- Entity ids become **path-dependent**: they depend on ingestion order.
+  Replaying the same data in different batch boundaries yields the same
+  *grouping* with possibly different id biographies. Dev and prod can differ.
+- A future full refresh reassigns ids (it re-derives content-addressed
+  labels). Full refreshes become rare, announced events, not a scheduled
+  crutch.
+
+This is acceptable because of the position taken in §2.3.
+
+### 2.2 The partition is monotone; only the labels are hard
+
+If edges only ever *arrive* (never get retracted), connected components are
+**monotone**: components merge, never split. Merging is associative,
+commutative, idempotent — the partition (which identifiers belong together)
+is order-insensitive. All order-sensitivity lives in the *labeling* (which
+entity_id names each group).
+
+Monotonicity yields the central computational trick — **prior state is a
+graph contraction**:
+
+> The identifier → entity_id mapping from the last run is a *lossless
+> summary of all prior connectivity*. Each resolved component enters the next
+> run's graph as a single contracted super-node. Connected components then
+> run over (touched super-nodes + new identifiers + new edges) only — a graph
+> proportional to **batch size**, not history size. Old edges are never
+> re-read.
+
+In union-find terms: the persisted mapping is a union-find structure fully
+path-compressed after every batch; every identifier points directly at its
+root, so "find" is a single join.
+
+An alternative "look-ahead" design (pull the full edge sets of touched
+components into a dirty-subgraph and re-run CC over raw edges) is also
+correct, but suffers adverse selection: the probability a component is
+touched by a batch scales with its activity, which correlates with its size —
+so the largest components get fully re-resolved almost every run. Contraction
+represents a touched 100k-identifier component as one node. Expansion is kept
+conceptually in reserve as the *split surgery* tool (§2.5), not the daily
+path.
+
+### 2.3 Entity ids are surrogate keys; identifiers are the API
+
+Every entry point into the system is "look up the entity by an identifier"
+(Kevin by his email). So identifiers are the stable external names; entity_id
+is internal bookkeeping whose only jobs are (a) consistency at any point in
+time, and (b) changing rarely enough that changes are **enumerable**.
+Identifier-based lookup is self-healing across merges: the path to the entity
+survives even when the id doesn't.
+
+The enumerable-changes property is load-bearing: the incremental algorithm
+hands downstream a tight contract — *the set of entity_ids that changed this
+run = newly born entities + the merge log*. If ids could churn on pure
+accretion (as the content-addressed scheme does when a new identifier sorts
+lexicographically first), that contract dissolves and downstream
+incrementality is impossible regardless of how clever the resolver is.
+
+Merge survivor selection is inherently arbitrary (CRMs punt it to a human),
+so the tie-break serves engineering: **the entity with the most existing
+mapping rows survives**, minimizing rewrites; entity_id breaks ties
+deterministically.
+
+### 2.4 Downstream tables are caches; the merge log is the invalidation stream
+
+Materialized entity_ids in participants/traits/states are denormalized caches
+of "resolve this identifier as of now." A merge is a cache-invalidation event.
+The resolution log (§4.5) is the invalidation stream: downstream incremental
+models re-emit exactly the rows whose entity_id appears as a
+`previous_entity_id` in log entries newer than their watermark. The same
+`repointed` rows double as an outbound merge/alias protocol for external
+tools (Segment alias, Mixpanel merge, customer.io, …).
+
+### 2.5 Splits are out of the incremental flow, by design
+
+Everything above rests on monotonicity. Three things violate it: retroactive
+noise filtering (an identifier's connection count crosses a threshold and its
+historical edges get disqualified), data corrections, and deletion requests.
+Removing an edge can shatter a component, and no summary kept from the
+monotone world can answer "is there another path?" — this is the decremental
+connectivity problem, fundamentally harder than incremental (union-find has
+no un-union).
+
+Position taken:
+
+- **Merges** are incremental facts, handled every batch.
+- **Splits** are rare, local, explicitly-targeted events, handled by
+  re-resolving *one component from its raw edges* (the look-ahead/expansion
+  algorithm, run on demand) or by full refresh. Never part of the standard
+  dbt flow. This is why the raw edge table is retained even though the
+  resolver never reads it again.
+- **Global full refresh** is reserved for *rule changes* (normalization,
+  edge-generation logic), where every component is suspect and nothing can be
+  localized.
+
+Consequently, incremental mode is **incompatible with edge autofiltering**
+(`edge_quality.critical_autofilter` / `error_autofilter`): admit-then-revoke
+filtering is anti-monotone. `create_identifier_edges` raises a compile error
+if both are enabled. The monotone replacement — quarantine-on-entry, where an
+identifier already known to be promiscuous never bridges anything — is future
+work (§7).
+
+### 2.6 Knowledge timeline vs. world timeline
+
+Monotonicity is a claim about the **ingestion** timeline (`_ingested_at`),
+not the event timeline (`occurred_at`). The identifier graph is atemporal:
+an edge is a set-membership fact, and the partition is order-insensitive, so
+out-of-order ingestion is harmless — a 2019 event arriving today produces
+exactly the partition it would have produced arriving in 2019. Late data just
+means a merge happens later than it could have.
+
+Two consequences with teeth:
+
+1. **Watermarks are always on `_ingested_at`, never `occurred_at`.** Filtering
+   the delta by event time silently drops backfills forever.
+2. Everything that *interprets* components (traits, states, attribution)
+   still orders by `occurred_at`, read off the rows — so those semantics are
+   also arrival-order-independent.
+
+## 3. The algorithm (one incremental run of the resolver)
+
+State carried between runs: the resolved mapping itself (`{{ this }}`).
+Nothing else is read from prior runs.
+
+1. **Delta.** Identifier rows and edges with `_ingested_at >` the max
+   watermark already absorbed into `{{ this }}`. Both are needed: a
+   single-identifier event produces no edge but must still mint or accrete.
+2. **Lookup.** Left-join every delta identifier against the prior mapping.
+   Each node is *known* (has an entity_id) or *new*.
+3. **Contract.** Build the dirty graph: node key = entity_id for known
+   identifiers (the super-node), a synthetic `unresolved|type|value` key for
+   new ones. Rewrite delta edges in node keys; edges internal to one existing
+   entity become self-loops and drop out.
+4. **Connected components** over the contracted graph — Jinja-unrolled
+   min-label propagation, adapter-generic (plain joins; the graph is tiny).
+   Real CC is required, not per-edge classification: within one batch, new
+   identifier X can link entity A in one event and new identifier Y in
+   another, and Y can link entity B — A∪X∪Y∪B is discoverable only by
+   traversal. Iteration count only needs to cover within-batch chain
+   diameter (prior components are single nodes), so small constants suffice.
+5. **Classify** each resulting component by distinct prior entity_ids:
+   - **0** → born: mint an id from the lexicographically-first identifier
+     (same format the full path would assign a brand-new component).
+   - **1** → accretion: the entity keeps its id.
+   - **≥2** → merge: biggest-entity-wins survivor; *every* mapping row of
+     every loser is re-pointed to the survivor (the whole component moves,
+     including identifiers not in this batch).
+6. **Emit only the change-set**: new identifier rows (`born` / `accreted`)
+   plus re-pointed loser rows (`repointed`, with `previous_entity_id`).
+   Untouched entities never appear; dbt's merge never touches their rows.
+7. **Stamp** every emitted row with `resolved_at_watermark = max(_ingested_at)`
+   of the delta — deterministic (no `now()`), so re-runs are idempotent and
+   the log has a clean cursor.
+
+Properties that fall out: empty delta → no-op; duplicate/overlapping batches
+→ no-ops (safe under at-least-once delivery and sloppy lookbacks); first run
+and `--full-refresh` see empty state and degrade to a full resolution;
+multi-batch merge chains (A absorbs B today, C absorbs A tomorrow) compose
+because the mapping is always fully compressed.
+
+## 4. dbt implementation
+
+### 4.1 Feature flag
+
+```yaml
+vars:
+  nexus:
+    incremental:
+      enabled: true   # default false
+```
+
+`nexus_incremental_enabled()` reads the flag;
+`nexus_incremental_materialization()` returns `'incremental'` or the previous
+default `'table'`, so each model file serves both modes. With the flag off,
+compiled SQL is unchanged except for three additive provenance columns on the
+resolved tables (§4.4).
+
+### 4.2 No batch coordination
+
+There is no shared batch id and no orchestration requirement. Every
+incremental model defines its own delta as "input rows with `_ingested_at`
+greater than the max I've already absorbed," checked against its own
+`{{ this }}`. Models can run at different cadences, retry, or overlap;
+monotonicity + idempotency make the worst case a redundant no-op.
+
+### 4.3 Upstream plumbing
+
+- `process_entity_identifiers` / `nexus_entity_identifiers`: now emits
+  `_ingested_at` (falling back to `occurred_at` for sources that lack it) and
+  appends only rows past the watermark in incremental mode.
+- `create_identifier_edges` / `nexus_entity_identifiers_edges`: emits
+  `_ingested_at` and `edge_uniqueness_hash`; in incremental mode derives
+  edges only from new identifier rows (both endpoints of an edge arrive with
+  the same event, so filtering rows filters whole edges) and anti-joins
+  against existing hashes so a re-derived edge keeps its first sighting's
+  `_ingested_at` (re-inserting would be a harmless but wasteful reprocess).
+  Raises a compile error if incremental mode is combined with edge
+  autofiltering (§2.5).
+
+### 4.4 The resolver
+
+`nexus_resolved_person_identifiers` / `nexus_resolved_group_identifiers`:
+
+- **Full path** (table mode, first run, `--full-refresh`): the existing
+  adapter-dispatched whole-graph traversal, now emitting three additional
+  columns: `resolution_reason='full_resolution'`, `previous_entity_id=null`,
+  and `resolved_at_watermark=` the global ingestion high-water mark at
+  resolution time (so a subsequent incremental run starts exactly where the
+  full resolution left off).
+- **Incremental path**: `incremental_resolve_identifiers()` implements §3.
+  `unique_key=['identifier_type','identifier_value']`; the merge strategy
+  overwrites re-pointed rows in place. The macro is adapter-generic — the
+  contracted graph is small enough that plain joins work everywhere, so the
+  per-warehouse dispatch surface does not grow.
+
+### 4.5 The resolution log
+
+`nexus_resolution_log` (built only when the flag is on): append-only record
+of every resolution decision, unioned across ER entity types, cursored on
+`resolved_at_watermark`. This is the merge log, the downstream invalidation
+stream, and the outbound alias protocol, in one artifact.
+
+It is also the **first table in the package that cannot be rebuilt from
+source data**: it records the history of what the pipeline concluded and
+when, which is path-dependent on ingestion order. It is protected with
+`full_refresh: false`; a full refresh of the resolver appends a new
+`full_resolution` epoch rather than erasing history. Treat it as
+system-of-record: back it up, never truncate casually.
+
+Caveat: the log captures the mapping's state per run of the log model. If the
+resolver runs multiple times before the log runs, intermediate hops for rows
+changed twice are collapsed into the latest state. Run the log in the same
+DAG invocation as the resolver (the default `dbt run` does).
+
+### 4.6 What is deliberately NOT incremental yet
+
+- **Downstream models** (participants, traits, states, entities): still full
+  rebuilds over now-complete mappings — unchanged semantics. Incrementalizing
+  them is the natural next phase; each one's delta is (new events) ∪ (rows
+  whose entity_id appears in new `repointed` log entries). The wide
+  `nexus_entities` pivot may stay a full rebuild indefinitely: its columns are
+  discovered at compile time (dynamic schema), and the entity dimension is
+  small next to the event-grain tables. Spend the incrementality budget where
+  the rows are.
+- **Source event-log models**: still full rebuilds. Straightforward
+  append-only incrementals, but orthogonal to identity resolution.
+- **Quarantine / connection-count maintenance** (§7).
+
+### 4.7 Known edge cases and assumptions
+
+- **Watermark boundary ties.** The delta predicate is strictly `>`. If a
+  loader stamps many rows with one `_ingested_at` and dbt runs mid-load, the
+  stragglers sharing the boundary timestamp are skipped. Mitigations: run
+  after loads complete, or add a lookback (reprocessing is idempotent).
+  A configurable lookback is future work.
+- **`max_recursion` semantics change** in incremental mode: it bounds
+  within-batch chain diameter over the contracted graph (small), not
+  historical component diameter. The default of 5 is generous; a chain of >5
+  distinct entities/identifiers linked in one batch would under-merge (the
+  next batch touching them heals it, but don't rely on that — raise the var
+  if batches are huge).
+- **Full refresh renumbers.** By design (§2.1). Downstream systems holding
+  entity_ids must treat a full refresh as an id-migration event; the log's
+  new epoch is the migration record.
+
+## 5. Rollout: no fork
+
+Recommended path for working this into consumer projects over several cycles:
+
+1. The flag defaults **off**; merged to main, the package is inert. No fork
+   and no long-lived divergence needed — dbt consumers pin packages by git
+   revision, so a consumer opts into a testing cycle with:
+
+   ```yaml
+   packages:
+     - git: https://github.com/slide-rule-tech/dbt-nexus.git
+       revision: <branch-or-tag>
+   ```
+
+   and opts into the behavior (independently!) with the var. Two consumers on
+   the same revision can run different modes.
+2. First enablement in a consumer starts with `dbt run --full-refresh` of the
+   resolver subgraph (establishes the epoch), then normal runs.
+3. Keep a scheduled partition-equality check (§6.3) during the trust-building
+   period.
+
+Forking would only make sense to escape upstream review/permissions — it buys
+nothing here and costs continuous rebasing.
+
+## 6. Testing harness (design — not yet implemented)
+
+The core difficulty: incremental correctness is a property of **run
+sequences**, not states. dbt's native tests assert post-run state; something
+outside dbt must drive the sequence. Three layers:
+
+### 6.1 dbt unit tests (dbt ≥ 1.8) — single-run resolver logic
+
+dbt unit tests can mock `this` as a fixture and force `is_incremental()` via
+macro overrides. "Given this prior mapping and these delta rows, the model
+emits exactly this change-set" becomes declarative YAML — no warehouse,
+milliseconds. One fixture per classification case: born singleton, accretion,
+simple merge, within-batch chain (A–X, X–Y, Y–B must unify — exercises the CC
+step, not just lookups), survivor selection (bigger entity wins; entity_id
+tie-break), loser re-emission includes identifiers absent from the batch.
+
+### 6.2 Multi-run scenario harness on DuckDB — sequence properties
+
+A small script (~50 lines: bash or pytest) plus scenario seeds, against a
+throwaway `.duckdb` file. The trick that keeps scenarios declarative is a
+**simulated ingestion clock**: the entire scenario lives in one seed with an
+`_ingested_at` column; a test-only source shim gates rows with
+`where _ingested_at <= var('simulated_now')`; the harness advances the clock:
+
+```
+dbt seed
+dbt run  --vars 'simulated_now: 2024-01-01'   # batch 1
+dbt test                                       # invariants at t1
+dbt run  --vars 'simulated_now: 2024-01-02'   # batch 2
+dbt test                                       # invariants at t2
+```
+
+Scenario list (each is one seed + a clock sequence + expected partitions):
+
+- singleton birth; accretion; simple two-entity merge
+- merge chain within a batch; merge chain **across** batches
+  (A absorbs B, then C absorbs A — verifies compression composes)
+- duplicate batch re-ingestion → byte-identical state (idempotency)
+- out-of-order / late arrival → same partition as in-order
+- empty batch → no-op
+- **property test**: replay the same seed under different batch slicings
+  (one big batch, daily, shuffled) and assert identical partitions — this
+  tests the order-insensitivity theorem itself, cheaply
+
+Invariants after every step are plain dbt data tests (they ARE state
+assertions):
+
+- **partition equality**: a shadow model full-resolves the clock-visible
+  slice from scratch; compare **component memberships** (sets of identifiers
+  grouped together), ignoring entity_ids — test the theorem, not the
+  arbitrary bookkeeping
+- every identifier maps to exactly one live entity_id; no mapping row points
+  at an entity_id that appears as a `previous_entity_id` loser
+- log is append-only and monotone in `resolved_at_watermark`; every
+  `repointed` mapping state has a matching log entry
+- id format parity: born ids match the full path's format
+
+### 6.3 Production invariant tests (shipped in the package)
+
+The partition-equality and mapping-hygiene checks packaged as generic tests,
+run on a schedule against real data. This converts "trust the incremental
+logic" into a monitored property and is what makes full refreshes rare rather
+than a weekly safety ritual. The classic failure mode it catches: a watermark
+bug silently skipping rows, which no single-run test can see.
+
+### 6.4 Where it lives
+
+An `integration_tests/` sub-project inside this repo (the dbt-utils pattern:
+its `packages.yml` installs the package via `local: ..`). That is the
+"consumer project" — it catches consumed-as-a-package failures (var wiring,
+source indirection) without a separate repo. The simulated-clock source shims
+belong there, not in package code: a real consumer must never inherit a
+`simulated_now` gate. DuckDB is the target for the inner loop (already
+supported via `install_duckdb_compat`); a thin nightly cross-adapter smoke
+run on BigQuery/Snowflake covers dialect quirks the algorithm's plain joins
+mostly avoid.
+
+## 7. Future work
+
+- **Quarantine-on-entry noise filtering**: an incrementally-maintained
+  per-identifier connection-count aggregate; identifiers crossing thresholds
+  are quarantined *before* their edges enter the graph (monotone-safe:
+  admitting late merges; revoking never happens incrementally). Requires the
+  resolver's lookup to treat quarantined identifiers as known-but-non-bridging.
+- **Downstream incrementalization** off the resolution log (§4.6).
+- **Split surgery tooling**: an operator-invoked routine that re-expands one
+  component from raw edges, re-resolves it, and emits `split` log entries.
+- **Outbox consumers**: per-consumer cursors over the resolution log for
+  webhooks / reverse-ETL merge calls (trait-change events belong to the same
+  pattern once traits are incremental).
+- **Configurable watermark lookback** for loaders with coarse `_ingested_at`.

--- a/docs/incremental-identity-resolution.md
+++ b/docs/incremental-identity-resolution.md
@@ -183,12 +183,22 @@ Nothing else is read from prior runs.
    - **≥2** → merge: biggest-entity-wins survivor; *every* mapping row of
      every loser is re-pointed to the survivor (the whole component moves,
      including identifiers not in this batch).
-6. **Emit only the change-set**: new identifier rows (`born` / `accreted`)
-   plus re-pointed loser rows (`repointed`, with `previous_entity_id`).
-   Untouched entities never appear; dbt's merge never touches their rows.
-7. **Stamp** every emitted row with `resolved_at_watermark = max(_ingested_at)`
+6. **Emit the change-set**: new identifier rows (`born` / `accreted`) plus
+   re-pointed loser rows (`repointed`, with `previous_entity_id`). Untouched
+   entities never appear; dbt's merge never touches their rows.
+7. **Re-emit observations** (`reobserved`): known identifiers seen in this
+   batch whose entity didn't change get their existing mapping row re-emitted
+   unchanged except for the reason and a fresh watermark. This carries no new
+   information — it exists so that *every* processed delta row is covered by
+   an emitted row bearing the batch watermark. Without it, a steady-state
+   batch of already-known identifiers (the common case: the same people
+   showing up again) would emit nothing, `max(resolved_at_watermark)` would
+   stagnate, and every subsequent run would re-scan an ever-growing delta.
+   Bounded by batch size; excluded from the resolution log.
+8. **Stamp** every emitted row with `resolved_at_watermark = max(_ingested_at)`
    of the delta — deterministic (no `now()`), so re-runs are idempotent and
-   the log has a clean cursor.
+   the log has a clean cursor. Steps 6–8 together guarantee the watermark
+   advances past the full processed delta on every non-empty run.
 
 Properties that fall out: empty delta → no-op; duplicate/overlapping batches
 → no-ops (safe under at-least-once delivery and sloppy lookbacks); first run
@@ -256,7 +266,10 @@ monotonicity + idempotency make the worst case a redundant no-op.
 `nexus_resolution_log` (built only when the flag is on): append-only record
 of every resolution decision, unioned across ER entity types, cursored on
 `resolved_at_watermark`. This is the merge log, the downstream invalidation
-stream, and the outbound alias protocol, in one artifact.
+stream, and the outbound alias protocol, in one artifact. `reobserved` rows
+never enter it — observation is watermark bookkeeping, not a resolution
+decision (and the cursor stays safe across reobserved-only batches because
+batch watermarks are strictly increasing).
 
 It is also the **first table in the package that cannot be rebuilt from
 source data**: it records the history of what the pipeline concluded and
@@ -291,6 +304,19 @@ DAG invocation as the resolver (the default `dbt run` does).
   stragglers sharing the boundary timestamp are skipped. Mitigations: run
   after loads complete, or add a lookback (reprocessing is idempotent).
   A configurable lookback is future work.
+- **The `occurred_at` fallback is a backfill hazard.** Sources without
+  `_ingested_at` use `occurred_at` as the watermark column. For those sources
+  a backfilled old event (old `occurred_at`, arriving today) lands *behind*
+  the watermark and is never processed by the resolver. Safe only if such a
+  source's data arrives in roughly event-time order; give real sources a real
+  `_ingested_at`.
+- **The edges table's watermark can idle on pair-free batches.** A batch
+  containing only single-identifier events produces no edges, so the edge
+  model's own high-water mark doesn't advance and those identifier rows are
+  re-scanned by the edge self-join on subsequent runs until a batch with
+  pairs arrives. Benign: the anti-join makes re-derivation a no-op, rows from
+  different events never share an `edge_id` (no spurious cross-batch edges),
+  and the resolver's watermark advances independently via `reobserved` rows.
 - **`max_recursion` semantics change** in incremental mode: it bounds
   within-batch chain diameter over the contracted graph (small), not
   historical component diameter. The default of 5 is generous; a chain of >5

--- a/macros/config/nexus_incremental_enabled.sql
+++ b/macros/config/nexus_incremental_enabled.sql
@@ -1,0 +1,29 @@
+{# Feature flag for incremental identity resolution.
+
+    Consumers opt in via:
+
+        vars:
+          nexus:
+            incremental:
+              enabled: true
+
+    Defaults to false: every model behaves exactly as before (full
+    rebuild as `table`). See docs/incremental-identity-resolution.md
+    for the design and the semantic changes that come with enabling it
+    (most importantly: entity ids become stable-across-runs rather than
+    content-derived, and merges are recorded in nexus_resolution_log).
+#}
+{% macro nexus_incremental_enabled() %}
+  {{ return(var('nexus', {}).get('incremental', {}).get('enabled', false)) }}
+{% endmacro %}
+
+{# Materialization helper: incremental when the flag is on, otherwise the
+   existing default. Used in model config() blocks so the same model file
+   serves both modes. #}
+{% macro nexus_incremental_materialization(default='table') %}
+  {%- if nexus.nexus_incremental_enabled() -%}
+    {{ return('incremental') }}
+  {%- else -%}
+    {{ return(default) }}
+  {%- endif -%}
+{% endmacro %}

--- a/macros/entity-resolution/bigquery__resolve_identifiers.sql
+++ b/macros/entity-resolution/bigquery__resolve_identifiers.sql
@@ -156,7 +156,18 @@ select
   identifier_type,
   identifier_value,
   false as realtime_processed,
-  true as existing_{{ entity_type }}
+  true as existing_{{ entity_type }},
+  -- Resolution provenance (see incremental_resolve_identifiers): a full
+  -- resolution is its own epoch. The watermark is the global ingestion
+  -- high-water mark at resolution time so a subsequent incremental run
+  -- picks up exactly where this one left off.
+  'full_resolution' as resolution_reason,
+  cast(null as {{ dbt.type_string() }}) as previous_entity_id,
+  (
+    select max(_ingested_at)
+    from {{ ref(identifiers_table) }}
+    where entity_type = '{{ entity_type }}'
+  ) as resolved_at_watermark
 from deduplicated_identifiers
 where row_num = 1
 {% endmacro %}

--- a/macros/entity-resolution/create_identifier_edges.sql
+++ b/macros/entity-resolution/create_identifier_edges.sql
@@ -7,8 +7,33 @@
 {% set error_autofilter = edge_quality.get('error_autofilter', false) %}
 {% set error_threshold = edge_quality.get('error_threshold', 20) %}
 
+{# Retroactive edge autofiltering removes edges as connection counts grow,
+   which breaks the monotonicity (edges only ever arrive) that incremental
+   identity resolution depends on: removing edges can split components, and
+   splits cannot be processed incrementally. Fail loudly rather than let the
+   incremental graph silently diverge from a full refresh. #}
+{% if nexus.nexus_incremental_enabled() and (critical_autofilter or error_autofilter) %}
+  {{ exceptions.raise_compiler_error(
+      "nexus: incremental identity resolution (nexus.incremental.enabled) is "
+      ~ "incompatible with edge_quality autofiltering (critical_autofilter / "
+      ~ "error_autofilter). Autofiltering retroactively removes edges, which "
+      ~ "can split components -- splits require a full refresh. Disable "
+      ~ "autofiltering or disable incremental mode."
+  ) }}
+{% endif %}
+
 with unpivoted as (
   select * from {{ ref(identifiers_table) }}
+  {% if is_incremental() %}
+  -- Incremental mode: only identifier rows ingested after the high-water
+  -- mark. Both endpoints of an edge come from the same event (same edge_id),
+  -- so they always arrive in the same batch -- filtering the unpivoted rows
+  -- filters whole edges, never half of one.
+  where _ingested_at > coalesce(
+      (select max(_ingested_at) from {{ this }}),
+      cast('1970-01-01' as timestamp)
+  )
+  {% endif %}
 ),
 
 raw_edges as (
@@ -22,6 +47,8 @@ raw_edges as (
     b.identifier_value as identifier_value_b,
     -- Both a and b share the same edge_id, so they have the same source
     coalesce(a.source, b.source) as source,
+    -- Both sides come from the same event, so they share an ingestion batch
+    coalesce(a._ingested_at, b._ingested_at) as _ingested_at,
     -- Create uniqueness hash for deduplication (includes entity_type to prevent collisions)
     {{ dbt_utils.generate_surrogate_key([
       'a.entity_type',
@@ -49,6 +76,7 @@ deduplicated_edges as (
     identifier_type_b,
     identifier_value_b,
     source,
+    _ingested_at,
     edge_uniqueness_hash,
     row_number() over (partition by edge_uniqueness_hash order by edge_uniqueness_hash) as rn
   from raw_edges
@@ -91,9 +119,24 @@ select
   entity_type_b,
   identifier_type_b,
   identifier_value_b,
-  source
+  source,
+  _ingested_at,
+  edge_uniqueness_hash
 from edges_with_total_connection_counts
-where 
+where
+  {% if is_incremental() %}
+  -- An edge re-derived from a new event may already exist (same identifier
+  -- pair seen before via a different event). Keep the first sighting: its
+  -- _ingested_at must stay put so the resolver's watermark treats the edge
+  -- as already absorbed. Re-inserting would be harmless (idempotent no-op
+  -- downstream) but wasteful.
+  not exists (
+    select 1
+    from {{ this }} existing
+    where existing.edge_uniqueness_hash = edges_with_total_connection_counts.edge_uniqueness_hash
+  )
+  and
+  {% endif %}
   -- Filter out identifiers with connections exceeding thresholds (if enabled)
   {% if critical_autofilter or error_autofilter %}
   not (

--- a/macros/entity-resolution/duckdb__resolve_identifiers.sql
+++ b/macros/entity-resolution/duckdb__resolve_identifiers.sql
@@ -103,7 +103,18 @@ select
   identifier_type,
   identifier_value,
   false as realtime_processed,
-  true as existing_{{ entity_type }}
+  true as existing_{{ entity_type }},
+  -- Resolution provenance (see incremental_resolve_identifiers): a full
+  -- resolution is its own epoch. The watermark is the global ingestion
+  -- high-water mark at resolution time so a subsequent incremental run
+  -- picks up exactly where this one left off.
+  'full_resolution' as resolution_reason,
+  cast(null as {{ dbt.type_string() }}) as previous_entity_id,
+  (
+    select max(_ingested_at)
+    from {{ ref(identifiers_table) }}
+    where entity_type = '{{ entity_type }}'
+  ) as resolved_at_watermark
 from deduplicated_identifiers
 where row_num = 1
 

--- a/macros/entity-resolution/incremental_resolve_identifiers.sql
+++ b/macros/entity-resolution/incremental_resolve_identifiers.sql
@@ -22,8 +22,14 @@
 --                          rows of the losers are re-pointed to the survivor
 --                          and recorded with resolution_reason='repointed'
 --
--- The emitted rows are exactly the change-set (new + re-pointed); untouched
--- entities never appear, so dbt's merge never touches their rows.
+-- The emitted rows are the change-set (new + re-pointed) plus 'reobserved'
+-- re-emissions of known identifiers seen in this batch. Reobserved rows
+-- carry no new information -- they exist so every processed delta row is
+-- covered by an emitted row bearing the batch watermark, guaranteeing
+-- max(resolved_at_watermark) advances even on change-free batches (otherwise
+-- steady-state batches of already-known identifiers would re-scan an
+-- ever-growing delta forever). Entities untouched by the batch never appear,
+-- so dbt's merge never touches their rows.
 --
 -- Adapter-generic on purpose: the contracted graph is tiny, so plain joins
 -- plus a Jinja-unrolled min-label propagation work on every warehouse -- no
@@ -275,12 +281,44 @@ repointed_rows as (
     on l.loser_entity_id = t.{{ entity_type }}_id
 ),
 
+-- Change-set part 3: watermark advancement. A batch whose identifiers are
+-- all already known and produce no merges (the steady-state common case:
+-- the same people showing up again) would emit nothing, so
+-- max(resolved_at_watermark) would never advance and every subsequent run
+-- would re-scan an ever-growing delta. Re-emit the existing mapping rows of
+-- known identifiers observed in this batch -- unchanged except
+-- resolution_reason='reobserved' and the fresh watermark. Bounded by batch
+-- size. Excluded from nexus_resolution_log (observation is not a resolution
+-- decision). Loser-entity rows are excluded here because repointed_rows
+-- already re-emits them.
+reobserved_rows as (
+  select
+    t.{{ entity_type }}_id as entity_id,
+    t.identifier_type,
+    t.identifier_value,
+    t.event_id,
+    'reobserved' as resolution_reason,
+    cast(null as {{ dbt.type_string() }}) as previous_entity_id
+  from {{ this }} t
+  join delta_nodes dn
+    on dn.identifier_type = t.identifier_type
+    and dn.identifier_value = t.identifier_value
+  where dn.entity_id is not null
+    and not exists (
+      select 1 from losers l
+      where l.loser_entity_id = t.{{ entity_type }}_id
+    )
+),
+
 changes as (
   select entity_id, identifier_type, identifier_value, event_id, resolution_reason, previous_entity_id
   from new_identifier_rows
   union all
   select entity_id, identifier_type, identifier_value, event_id, resolution_reason, previous_entity_id
   from repointed_rows
+  union all
+  select entity_id, identifier_type, identifier_value, event_id, resolution_reason, previous_entity_id
+  from reobserved_rows
 )
 
 select

--- a/macros/entity-resolution/incremental_resolve_identifiers.sql
+++ b/macros/entity-resolution/incremental_resolve_identifiers.sql
@@ -1,0 +1,299 @@
+{% macro incremental_resolve_identifiers(entity_type, identifiers_table, edges_table, max_iterations=5) %}
+
+-- Incremental identity resolution via graph contraction.
+--
+-- See docs/incremental-identity-resolution.md for the full design. The short
+-- version: because edges only ever arrive (monotonicity), previously resolved
+-- components can never split -- they can only accrete new identifiers or
+-- merge with each other. The prior identifier -> entity_id mapping ({{ this }})
+-- is therefore a lossless summary of all prior connectivity: each resolved
+-- component enters this run's graph as a single contracted "super-node", and
+-- connected components run only over (touched super-nodes + new identifiers
+-- + new edges). Cost scales with batch size, not history size. Old edges are
+-- never re-read.
+--
+-- Per resulting component:
+--   0 prior entity_ids  -> a new entity is born (id minted from the
+--                          lexicographically-first identifier, same format
+--                          as the full-resolution path)
+--   1 prior entity_id   -> accretion; the entity keeps its id
+--   2+ prior entity_ids -> merge; the entity with the most existing mapping
+--                          rows survives (minimizes rewrites), all mapping
+--                          rows of the losers are re-pointed to the survivor
+--                          and recorded with resolution_reason='repointed'
+--
+-- The emitted rows are exactly the change-set (new + re-pointed); untouched
+-- entities never appear, so dbt's merge never touches their rows.
+--
+-- Adapter-generic on purpose: the contracted graph is tiny, so plain joins
+-- plus a Jinja-unrolled min-label propagation work on every warehouse -- no
+-- recursive-CTE dialect quirks. `max_iterations` only needs to cover the
+-- diameter of chains formed within ONE batch (not component diameter across
+-- history -- prior components are single nodes here), so the default of 5 is
+-- generous.
+
+with prior_state as (
+  select
+    identifier_type,
+    identifier_value,
+    {{ entity_type }}_id as entity_id
+  from {{ this }}
+),
+
+prior_watermark as (
+  select coalesce(max(resolved_at_watermark), cast('1970-01-01' as timestamp)) as wm
+  from {{ this }}
+),
+
+delta_identifiers as (
+  select ei.*
+  from {{ ref(identifiers_table) }} ei
+  where ei.entity_type = '{{ entity_type }}'
+    and ei.identifier_value is not null
+    and ei._ingested_at > (select wm from prior_watermark)
+),
+
+batch_watermark as (
+  select max(_ingested_at) as wm from delta_identifiers
+),
+
+delta_edges as (
+  select e.*
+  from {{ ref(edges_table) }} e
+  where e.entity_type_a = '{{ entity_type }}'
+    and e.entity_type_b = '{{ entity_type }}'
+    and e._ingested_at > (select wm from prior_watermark)
+),
+
+-- Contraction: every distinct identifier in the batch becomes a graph node.
+-- Known identifiers collapse onto their entity_id (the super-node); unknown
+-- identifiers stand as themselves under a collision-proof synthetic key.
+delta_nodes as (
+  select
+    d.identifier_type,
+    d.identifier_value,
+    p.entity_id,
+    case
+      when p.entity_id is not null then p.entity_id
+      else 'unresolved|' || d.identifier_type || '|' || d.identifier_value
+    end as node_key
+  from (
+    select distinct identifier_type, identifier_value
+    from delta_identifiers
+  ) d
+  left join prior_state p
+    on p.identifier_type = d.identifier_type
+    and p.identifier_value = d.identifier_value
+),
+
+-- Batch edges rewritten in contracted terms. Both endpoints of a delta edge
+-- are guaranteed to be delta identifiers (an edge's endpoints arrive with
+-- the same event). Edges internal to one existing entity contract to
+-- self-loops and drop out here.
+contracted_edges as (
+  select distinct
+    na.node_key as node_a,
+    nb.node_key as node_b
+  from delta_edges e
+  join delta_nodes na
+    on na.identifier_type = e.identifier_type_a
+    and na.identifier_value = e.identifier_value_a
+  join delta_nodes nb
+    on nb.identifier_type = e.identifier_type_b
+    and nb.identifier_value = e.identifier_value_b
+  where na.node_key != nb.node_key
+),
+
+sym_edges as (
+  select node_a, node_b from contracted_edges
+  union
+  select node_b as node_a, node_a as node_b from contracted_edges
+),
+
+-- Min-label propagation over the contracted graph, unrolled at compile time.
+labels_0 as (
+  select distinct node_key, node_key as label
+  from delta_nodes
+)
+{% for i in range(1, max_iterations + 1) %}
+,
+labels_{{ i }} as (
+  select node_key, min(label) as label
+  from (
+    select node_key, label from labels_{{ i - 1 }}
+    union all
+    select e.node_a as node_key, l.label
+    from sym_edges e
+    join labels_{{ i - 1 }} l
+      on l.node_key = e.node_b
+  ) neighborhood
+  group by node_key
+)
+{% endfor %}
+,
+
+nodes_labeled as (
+  select
+    dn.identifier_type,
+    dn.identifier_value,
+    dn.entity_id,
+    fl.label
+  from delta_nodes dn
+  join labels_{{ max_iterations }} fl
+    on fl.node_key = dn.node_key
+),
+
+-- Survivor selection for merges: the prior entity with the most existing
+-- mapping rows wins (fewest rows re-pointed); entity_id breaks ties
+-- deterministically.
+prior_entity_sizes as (
+  select
+    {{ entity_type }}_id as entity_id,
+    count(*) as n_rows
+  from {{ this }}
+  group by {{ entity_type }}_id
+),
+
+component_prior_entities as (
+  select distinct label, entity_id
+  from nodes_labeled
+  where entity_id is not null
+),
+
+survivors as (
+  select label, entity_id as survivor_entity_id
+  from (
+    select
+      cpe.label,
+      cpe.entity_id,
+      row_number() over (
+        partition by cpe.label
+        order by coalesce(pes.n_rows, 0) desc, cpe.entity_id
+      ) as rn
+    from component_prior_entities cpe
+    left join prior_entity_sizes pes
+      on pes.entity_id = cpe.entity_id
+  ) ranked
+  where rn = 1
+),
+
+-- Components containing no prior entity mint a fresh id from their
+-- lexicographically-first identifier -- identical in format to the id the
+-- full-resolution path would assign a brand-new component.
+minted as (
+  select
+    label,
+    {{ create_nexus_id(entity_type, ['identifier_type', 'identifier_value']) }} as minted_entity_id
+  from (
+    select
+      nl.label,
+      nl.identifier_type,
+      nl.identifier_value,
+      row_number() over (
+        partition by nl.label
+        order by nl.identifier_type, nl.identifier_value
+      ) as rn
+    from nodes_labeled nl
+    where not exists (
+      select 1 from component_prior_entities cpe
+      where cpe.label = nl.label
+    )
+  ) ranked
+  where rn = 1
+),
+
+component_entity as (
+  select
+    labels.label,
+    coalesce(s.survivor_entity_id, m.minted_entity_id) as entity_id,
+    s.survivor_entity_id is not null as has_prior_entity
+  from (select distinct label from nodes_labeled) labels
+  left join survivors s on s.label = labels.label
+  left join minted m on m.label = labels.label
+),
+
+-- Earliest occurrence per new identifier within the batch, mirroring the
+-- full path's dedup rule (keep the row with the lowest edge_id).
+delta_first_occurrence as (
+  select identifier_type, identifier_value, event_id
+  from (
+    select
+      identifier_type,
+      identifier_value,
+      event_id,
+      row_number() over (
+        partition by identifier_type, identifier_value
+        order by edge_id
+      ) as rn
+    from delta_identifiers
+  ) ranked
+  where rn = 1
+),
+
+-- Change-set part 1: previously unknown identifiers.
+new_identifier_rows as (
+  select
+    ce.entity_id,
+    nl.identifier_type,
+    nl.identifier_value,
+    fo.event_id,
+    case when ce.has_prior_entity then 'accreted' else 'born' end as resolution_reason,
+    cast(null as {{ dbt.type_string() }}) as previous_entity_id
+  from nodes_labeled nl
+  join component_entity ce
+    on ce.label = nl.label
+  join delta_first_occurrence fo
+    on fo.identifier_type = nl.identifier_type
+    and fo.identifier_value = nl.identifier_value
+  where nl.entity_id is null
+),
+
+-- Change-set part 2: merges. Every mapping row of every losing entity is
+-- re-pointed to the survivor -- including identifiers that never appeared
+-- in this batch (the whole component moves, not just the touched surface).
+losers as (
+  select distinct
+    nl.entity_id as loser_entity_id,
+    ce.entity_id as survivor_entity_id
+  from nodes_labeled nl
+  join component_entity ce
+    on ce.label = nl.label
+  where nl.entity_id is not null
+    and nl.entity_id != ce.entity_id
+),
+
+repointed_rows as (
+  select
+    l.survivor_entity_id as entity_id,
+    t.identifier_type,
+    t.identifier_value,
+    t.event_id,
+    'repointed' as resolution_reason,
+    t.{{ entity_type }}_id as previous_entity_id
+  from {{ this }} t
+  join losers l
+    on l.loser_entity_id = t.{{ entity_type }}_id
+),
+
+changes as (
+  select entity_id, identifier_type, identifier_value, event_id, resolution_reason, previous_entity_id
+  from new_identifier_rows
+  union all
+  select entity_id, identifier_type, identifier_value, event_id, resolution_reason, previous_entity_id
+  from repointed_rows
+)
+
+select
+  {{ create_nexus_id(entity_type ~ '_identifier', ['entity_id', 'identifier_type', 'identifier_value']) }} as {{ entity_type }}_identifier_id,
+  entity_id as {{ entity_type }}_id,
+  event_id,
+  identifier_type,
+  identifier_value,
+  false as realtime_processed,
+  true as existing_{{ entity_type }},
+  resolution_reason,
+  previous_entity_id,
+  (select wm from batch_watermark) as resolved_at_watermark
+from changes
+
+{% endmacro %}

--- a/macros/entity-resolution/snowflake__resolve_identifiers.sql
+++ b/macros/entity-resolution/snowflake__resolve_identifiers.sql
@@ -178,7 +178,18 @@ select
   identifier_type,
   identifier_value,
   false as realtime_processed,
-  true as existing_{{ entity_type }}
+  true as existing_{{ entity_type }},
+  -- Resolution provenance (see incremental_resolve_identifiers): a full
+  -- resolution is its own epoch. The watermark is the global ingestion
+  -- high-water mark at resolution time so a subsequent incremental run
+  -- picks up exactly where this one left off.
+  'full_resolution' as resolution_reason,
+  cast(null as {{ dbt.type_string() }}) as previous_entity_id,
+  (
+    select max(_ingested_at)
+    from {{ ref(identifiers_table) }}
+    where entity_type = '{{ entity_type }}'
+  ) as resolved_at_watermark
 from deduplicated_identifiers
 where row_num = 1
 

--- a/macros/event-log/process_entity_identifiers.sql
+++ b/macros/event-log/process_entity_identifiers.sql
@@ -22,13 +22,27 @@
         {% endfor %}
     {% endif %}
 
+    {# Detect whether any source relation carries _ingested_at. Sources that
+       lack it fall back to occurred_at, so the ingestion watermark used by
+       incremental mode degrades gracefully rather than failing to compile. #}
+    {% set ns = namespace(has_ingested_at=false) %}
+    {% if execute %}
+        {% for rel in relations_to_union %}
+            {% for col in adapter.get_columns_in_relation(rel) %}
+                {% if col.name | lower == '_ingested_at' %}
+                    {% set ns.has_ingested_at = true %}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
+    {% endif %}
+
     {% if relations_to_union %}
         with unioned as (
             {{ dbt_utils.union_relations(
                 relations=relations_to_union
             ) }}
         ),
-        
+
         normalized as (
             -- Standardize identifier formats (lowercase emails, etc.)
             select
@@ -47,7 +61,12 @@
                 end as normalized_value,
                 role,
                 source,
-                occurred_at
+                occurred_at,
+                {% if ns.has_ingested_at %}
+                coalesce(_ingested_at, occurred_at) as _ingested_at
+                {% else %}
+                occurred_at as _ingested_at
+                {% endif %}
             from unioned
         )
 
@@ -61,8 +80,18 @@
             normalized_value,
             role,
             source,
-            occurred_at
+            occurred_at,
+            _ingested_at
         from normalized
+        {% if is_incremental() %}
+        -- Incremental mode: only rows ingested after the high-water mark.
+        -- Watermark is on ingestion time, never occurred_at -- late-arriving
+        -- events (old occurred_at, new _ingested_at) must still enter.
+        where _ingested_at > coalesce(
+            (select max(_ingested_at) from {{ this }}),
+            cast('1970-01-01' as timestamp)
+        )
+        {% endif %}
     {% else %}
         {# Return empty result if no relations found #}
         select 
@@ -75,7 +104,8 @@
             cast(null as string) as normalized_value,
             cast(null as string) as role,
             cast(null as string) as source,
-            cast(null as timestamp) as occurred_at
+            cast(null as timestamp) as occurred_at,
+            cast(null as timestamp) as _ingested_at
         where 1=0
     {% endif %}
 {% endmacro %}

--- a/models/intermediate/entities/nexus_entity_identifiers.sql
+++ b/models/intermediate/entities/nexus_entity_identifiers.sql
@@ -1,4 +1,7 @@
-{{ config(materialized='table', tags=['identity-resolution', 'event-processing', 'entities']) }}
+{{ config(
+    materialized=nexus.nexus_incremental_materialization(),
+    on_schema_change='append_new_columns',
+    tags=['identity-resolution', 'event-processing', 'entities']
+) }}
 
 {{ nexus.process_entity_identifiers() }}
-

--- a/models/intermediate/identity-resolution/nexus_entity_identifiers_edges.sql
+++ b/models/intermediate/identity-resolution/nexus_entity_identifiers_edges.sql
@@ -1,4 +1,8 @@
-{{ config(materialized='table', tags=['identity-resolution', 'entities']) }}
+{{ config(
+    materialized=nexus.nexus_incremental_materialization(),
+    unique_key='edge_uniqueness_hash',
+    on_schema_change='append_new_columns',
+    tags=['identity-resolution', 'entities']
+) }}
 
 {{ nexus.create_identifier_edges('nexus_entity_identifiers') }}
-

--- a/models/intermediate/identity-resolution/nexus_resolution_log.sql
+++ b/models/intermediate/identity-resolution/nexus_resolution_log.sql
@@ -47,8 +47,14 @@ select
     resolution_reason,
     resolved_at_watermark
 from changes
+-- 'reobserved' rows are watermark bookkeeping (a known identifier seen
+-- again), not resolution decisions -- they never enter the log. Safe with
+-- the watermark cursor below: batch watermarks are strictly increasing, so
+-- a later loggable batch always clears a cursor left behind by
+-- reobserved-only batches.
+where resolution_reason != 'reobserved'
 {% if is_incremental() %}
-where resolved_at_watermark > coalesce(
+  and resolved_at_watermark > coalesce(
     (select max(resolved_at_watermark) from {{ this }}),
     cast('1970-01-01' as timestamp)
 )

--- a/models/intermediate/identity-resolution/nexus_resolution_log.sql
+++ b/models/intermediate/identity-resolution/nexus_resolution_log.sql
@@ -1,0 +1,55 @@
+{{ config(
+    enabled=nexus.nexus_incremental_enabled(),
+    materialized='incremental',
+    full_refresh=false,
+    tags=['identity-resolution'],
+) }}
+
+{# Append-only record of every identity-resolution decision: entities born,
+   identifiers accreted, and merges (rows re-pointed from a losing entity to
+   a survivor). This is the change-set downstream consumers key off -- the
+   set of entity_ids affected by a run is exactly the entity_ids appearing
+   here, and 'repointed' rows double as an outbound merge/alias protocol for
+   external tools.
+
+   Unlike every other model in the package, this table is NOT derivable from
+   source data: it records the history of what the pipeline concluded and
+   when, which is path-dependent on ingestion order. full_refresh=false
+   protects it; a full refresh of the resolver appends a new
+   'full_resolution' epoch here rather than erasing history. #}
+
+{% set er_types = nexus.get_er_entity_types() %}
+
+with changes as (
+    {% for entity_type in er_types %}
+    select
+        '{{ entity_type }}' as entity_type,
+        identifier_type,
+        identifier_value,
+        {{ entity_type }}_id as entity_id,
+        previous_entity_id,
+        resolution_reason,
+        resolved_at_watermark
+    from {{ ref('nexus_resolved_' ~ entity_type ~ '_identifiers') }}
+    {% if not loop.last %}
+    union all
+    {% endif %}
+    {% endfor %}
+)
+
+select
+    {{ nexus.create_nexus_id('resolution', ['entity_type', 'identifier_type', 'identifier_value', 'entity_id', 'resolution_reason', 'resolved_at_watermark']) }} as resolution_id,
+    entity_type,
+    identifier_type,
+    identifier_value,
+    entity_id,
+    previous_entity_id,
+    resolution_reason,
+    resolved_at_watermark
+from changes
+{% if is_incremental() %}
+where resolved_at_watermark > coalesce(
+    (select max(resolved_at_watermark) from {{ this }}),
+    cast('1970-01-01' as timestamp)
+)
+{% endif %}

--- a/models/intermediate/identity-resolution/types/nexus_resolved_group_identifiers.sql
+++ b/models/intermediate/identity-resolution/types/nexus_resolved_group_identifiers.sql
@@ -1,10 +1,16 @@
 {{ config(
-    materialized='table', 
+    materialized=nexus.nexus_incremental_materialization(),
+    unique_key=['identifier_type', 'identifier_value'],
+    on_schema_change='append_new_columns',
     tags=['identity-resolution', 'groups'],
 ) }}
 
--- Uses unified entity_identifiers_edges table, filters by entity_type='group' in the macro
+{# Uses the unified entity_identifiers/edges tables, filtered to
+   entity_type='group' inside the macros. See
+   nexus_resolved_person_identifiers.sql for the full/incremental split. #}
+{% if is_incremental() %}
+{{ nexus.incremental_resolve_identifiers('group', 'nexus_entity_identifiers', 'nexus_entity_identifiers_edges', var('nexus', {}).get('max_recursion') or var('nexus_max_recursion', 5)) }}
+{% else %}
 {# Support both new unified config and legacy variable #}
 {{ resolve_identifiers('group', 'nexus_entity_identifiers', 'nexus_entity_identifiers_edges', var('nexus', {}).get('max_recursion') or var('nexus_max_recursion', 10)) }}
-
-
+{% endif %}

--- a/models/intermediate/identity-resolution/types/nexus_resolved_person_identifiers.sql
+++ b/models/intermediate/identity-resolution/types/nexus_resolved_person_identifiers.sql
@@ -1,8 +1,24 @@
 {{ config(
-    materialized='table', 
+    materialized=nexus.nexus_incremental_materialization(),
+    unique_key=['identifier_type', 'identifier_value'],
+    on_schema_change='append_new_columns',
     tags=['identity-resolution', 'persons'],
 ) }}
 
--- Uses unified entity_identifiers_edges table, filters by entity_type='person' in the macro
+{# Uses the unified entity_identifiers/edges tables, filtered to
+   entity_type='person' inside the macros.
+
+   Full path (table mode, first incremental run, --full-refresh): whole-graph
+   traversal; entity ids are content-derived from each component's
+   lexicographically-first identifier.
+
+   Incremental path: contraction over the batch delta reading prior state
+   from {{ this }}; existing entities keep their ids, merges re-point the
+   losing entity's rows to the survivor. See
+   docs/incremental-identity-resolution.md. #}
+{% if is_incremental() %}
+{{ nexus.incremental_resolve_identifiers('person', 'nexus_entity_identifiers', 'nexus_entity_identifiers_edges', var('nexus', {}).get('max_recursion') or var('nexus_max_recursion', 5)) }}
+{% else %}
 {# Support both new unified config and legacy variable #}
 {{ nexus.resolve_identifiers('person', 'nexus_entity_identifiers', 'nexus_entity_identifiers_edges', var('nexus', {}).get('max_recursion') or var('nexus_max_recursion', 10)) }}
+{% endif %}


### PR DESCRIPTION
## Summary

Adds an experimental **incremental mode for the identity-resolution subgraph**, gated behind `nexus.incremental.enabled` (default `false` — with the flag off, behavior is unchanged apart from three additive provenance columns on the resolved tables).

The full design rationale, algorithm spec, and testing-harness design live in **`docs/incremental-identity-resolution.md`** — that doc is the primary artifact of this PR and captures the conceptual groundwork: partition-vs-labels, monotonicity, why prior state is a lossless graph contraction, the entity-id stability contract, merges as first-class facts, and why splits stay out of the standard flow.

## What changed

**The algorithm** (`macros/entity-resolution/incremental_resolve_identifiers.sql`, new):
- Prior resolved components enter each run as single contracted super-nodes read from `{{ this }}`; connected components (Jinja-unrolled min-label propagation, adapter-generic) run only over the batch delta. Cost scales with **batch size, not history size** — old edges are never re-read.
- Each resulting component classifies as **born** (mint id, same format as the full path), **accreted** (entity keeps its id), or **merged** (the entity with the most existing mapping rows survives; every mapping row of each loser is re-pointed with `resolution_reason='repointed'` and `previous_entity_id`).
- The model emits only the change-set; untouched entities are never rewritten. Idempotent under re-ingestion; safe under out-of-order arrival (watermarks are strictly on `_ingested_at`, never `occurred_at`).

**The resolution log** (`models/intermediate/identity-resolution/nexus_resolution_log.sql`, new):
- Append-only, `full_refresh`-protected record of every resolution decision. Doubles as the downstream cache-invalidation stream and an outbound merge/alias protocol. Only built when the flag is on.

**Plumbing:**
- `nexus_entity_identifiers` and `nexus_entity_identifiers_edges` gain `_ingested_at` (falling back to `occurred_at` for sources without it) and become watermark-append incrementals under the flag; edges expose `edge_uniqueness_hash` and keep first-sighting `_ingested_at` on re-derived pairs.
- All three full-resolution adapters (BigQuery/Snowflake/DuckDB) now emit `resolution_reason='full_resolution'`, `previous_entity_id`, `resolved_at_watermark` so a full refresh forms an epoch an incremental run continues from seamlessly.
- Compile-time guard: incremental mode + `edge_quality` autofiltering fails loudly (retroactive edge removal can split components; splits are not incrementally computable — see doc §2.5).

**Deliberately not in scope** (doc §4.6): downstream model incrementalization (participants/traits/states — their delta contract off the log is specified), source event-log incrementals, quarantine-on-entry noise filtering, and the testing harness (fully designed in doc §6, to be implemented in a local env).

## Semantics change to be aware of

Enabling the flag flips entity ids from **content-derived** (reproducible from scratch) to **prefix-stable** (never churn except across merges, which are enumerated in the log). A future `--full-refresh` renumbers entities and starts a new epoch. This is deliberate and argued for in doc §2.1–2.3.

## Validation

- `dbt parse` clean on dbt 1.11 / dbt-duckdb with the flag off and on.
- Autofilter-guard verified to raise a compile error when combined with incremental mode.
- Runtime validation (multi-run scenarios, partition-equality vs full refresh) is designed in doc §6 and intentionally deferred to the testing-harness implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RBBJ8YEcGUyXcHES35KkC

---
_Generated by [Claude Code](https://claude.ai/code/session_019RBBJ8YEcGUyXcHES35KkC)_