### PR TITLE
feat(semantic-layers): new source + warehouse-path for metrics/dimensions metadata

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: "nexus"
-version: "0.2.1"
+version: "0.2.2"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.

--- a/models/metadata/nexus_event_dimensions_metadata.sql
+++ b/models/metadata/nexus_event_dimensions_metadata.sql
@@ -1,12 +1,94 @@
 {{ config(materialized='table') }}
 
 -- Nexus Event Dimensions Metadata
--- Warehouse stats per (dimension_name, source) plus YAML-authored catalog fields.
--- FULL OUTER JOIN surfaces YAML-only dimensions with is_in_data = false.
+-- Warehouse stats per (dimension_name, source) plus catalog fields from the
+-- semantic layer. FULL OUTER JOIN surfaces catalog-only dimensions with
+-- is_in_data = false.
+--
+-- yaml_dimensions source priority:
+--   1. Warehouse: var('nexus').sources.semantic_layers.enabled = true → BBP source
+--   2. Vars: var('nexus').dimensions list (legacy; remove after warehouse verified)
+--   3. Empty CTE (warehouse stats still populate the right side of the FULL OUTER JOIN)
 
+{% set use_warehouse = var('nexus', {}).get('sources', {}).get('semantic_layers', {}).get('enabled', false) %}
 {% set all_dimensions = var('nexus', {}).get('dimensions', []) %}
 
-{% if all_dimensions | length > 0 %}
+{% if use_warehouse %}
+
+-- ── Warehouse path ────────────────────────────────────────────────────────────
+WITH yaml_dimensions AS (
+    with latest as (
+        select _raw_record
+        from {{ source('semantic_layers', 'semantic_layers') }}
+        qualify row_number() over (
+            partition by
+            {% if target.type == 'bigquery' %}
+                json_value(_raw_record, '$.organization_id'),
+                json_value(_raw_record, '$.layer_slug')
+            {% else %}
+                _raw_record:organization_id::string,
+                _raw_record:layer_slug::string
+            {% endif %}
+            order by _ingested_at desc
+        ) = 1
+    )
+
+    {% if target.type == 'bigquery' %}
+    select
+        json_value(d, '$.name') as dimension_name,
+        coalesce(
+            nullif(json_value(d, '$.label'), ''),
+            initcap(replace(json_value(d, '$.name'), '_', ' '))
+        ) as label,
+        json_value(d, '$.description') as description,
+        nullif(
+            array_to_string(
+                array(select json_value(x) from unnest(json_query_array(d, '$.aliases')) as x),
+                ', '
+            ), ''
+        ) as aliases,
+        nullif(
+            array_to_string(
+                array(select json_value(x) from unnest(json_query_array(d, '$.tags')) as x),
+                ', '
+            ), ''
+        ) as tags,
+        nullif(
+            array_to_string(
+                array(select json_value(x) from unnest(json_query_array(d, '$.example_questions')) as x),
+                '; '
+            ), ''
+        ) as example_questions
+    from latest,
+         unnest(json_query_array(_raw_record, '$.layer.dimensions')) as d
+    {% else %}
+    select
+        d.value:name::string as dimension_name,
+        coalesce(
+            nullif(d.value:label::string, ''),
+            initcap(replace(d.value:name::string, '_', ' '))
+        ) as label,
+        d.value:description::string as description,
+        nullif(
+            (select listagg(f.value::string, ', ') from lateral flatten(input => d.value:aliases) f),
+            ''
+        ) as aliases,
+        nullif(
+            (select listagg(f.value::string, ', ') from lateral flatten(input => d.value:tags) f),
+            ''
+        ) as tags,
+        nullif(
+            (select listagg(f.value::string, '; ') from lateral flatten(input => d.value:example_questions) f),
+            ''
+        ) as example_questions
+    from latest,
+         lateral flatten(input => _raw_record:layer:dimensions) d
+    {% endif %}
+),
+
+{% elif all_dimensions | length > 0 %}
+
+-- ── Legacy vars path ──────────────────────────────────────────────────────────
 WITH yaml_dimensions AS (
     {% set ns = namespace(first=true) %}
     {% for dim in all_dimensions %}
@@ -27,7 +109,10 @@ WITH yaml_dimensions AS (
             {% if dim.get('example_questions') %}{{ nexus.metrics_metadata_sql_str(dim.example_questions | join('; ')) }}{% else %}NULL{% endif %} AS example_questions
     {% endfor %}
 ),
+
 {% else %}
+
+-- ── Empty catalog ─────────────────────────────────────────────────────────────
 WITH yaml_dimensions AS (
     {% if target.type == 'bigquery' %}
     SELECT
@@ -49,6 +134,7 @@ WITH yaml_dimensions AS (
     WHERE 1 = 0
     {% endif %}
 ),
+
 {% endif %}
 
 warehouse_stats AS (

--- a/models/metadata/nexus_metrics_metadata.sql
+++ b/models/metadata/nexus_metrics_metadata.sql
@@ -1,10 +1,131 @@
 {{ config(materialized='table') }}
 
-{% set all_metrics = var('nexus', {}).get('metrics', {}) %}
+{#
+  Nexus Metrics Metadata — one row per metric in the org's semantic layer.
 
+  Source priority:
+    1. Warehouse: if var('nexus').sources.semantic_layers.enabled = true, read
+       from the BBP-projected `semantic_layers` collection (the new path).
+    2. Vars: fall back to var('nexus').metrics (legacy dbt-variables approach,
+       present during transition; remove from client dbt_project.yml after
+       verifying warehouse data matches).
+    3. Empty: no metrics configured → type-safe zero-row result.
+#}
+
+{% set use_warehouse = var('nexus', {}).get('sources', {}).get('semantic_layers', {}).get('enabled', false) %}
+{% set all_metrics = var('nexus', {}).get('metrics', {}) %}
 {% set has_metrics = all_metrics | length > 0 %}
 
-{% if has_metrics %}
+{% if use_warehouse %}
+
+-- ── Warehouse path ────────────────────────────────────────────────────────────
+-- Read the latest semantic layer row per (organization_id, layer_slug) and
+-- unnest the metrics array. Adapter-portable (BigQuery JSON vs Snowflake VARIANT).
+
+with latest as (
+    select _raw_record, _ingested_at
+    from {{ source('semantic_layers', 'semantic_layers') }}
+    qualify row_number() over (
+        partition by
+        {% if target.type == 'bigquery' %}
+            json_value(_raw_record, '$.organization_id'),
+            json_value(_raw_record, '$.layer_slug')
+        {% else %}
+            _raw_record:organization_id::string,
+            _raw_record:layer_slug::string
+        {% endif %}
+        order by _ingested_at desc
+    ) = 1
+)
+
+{% if target.type == 'bigquery' %}
+select
+    json_value(m, '$.model') as model,
+    json_value(m, '$.name') as metric_name,
+    json_value(m, '$.label') as label,
+    nullif(
+        array_to_string(
+            array(select json_value(x) from unnest(json_query_array(m, '$.aliases')) as x),
+            ', '
+        ), ''
+    ) as aliases,
+    json_value(m, '$.type') as metric_type,
+    nullif(
+        array_to_string(
+            array(select json_value(x) from unnest(json_query_array(m, '$.tables')) as x),
+            ', '
+        ), ''
+    ) as tables,
+    json_value(m, '$.metric_sql') as metric_sql,
+    nullif(
+        array_to_string(
+            array(select json_value(x) from unnest(json_query_array(m, '$.filter')) as x),
+            ' AND '
+        ), ''
+    ) as filter,
+    json_value(m, '$.format') as format,
+    json_value(m, '$.unit') as unit,
+    json_value(m, '$.polarity') as polarity,
+    cast(json_value(m, '$.precision') as int64) as precision,
+    nullif(
+        array_to_string(
+            array(select json_value(x) from unnest(json_query_array(m, '$.tags')) as x),
+            ', '
+        ), ''
+    ) as tags,
+    json_value(m, '$.description') as description,
+    nullif(
+        array_to_string(
+            array(select json_value(x) from unnest(json_query_array(m, '$.example_questions')) as x),
+            '; '
+        ), ''
+    ) as example_questions
+from latest,
+     unnest(json_query_array(_raw_record, '$.layer.metrics')) as m
+
+{% else %}
+
+select
+    m.value:model::string as model,
+    m.value:name::string as metric_name,
+    m.value:label::string as label,
+    nullif(
+        (select listagg(f.value::string, ', ') from lateral flatten(input => m.value:aliases) f),
+        ''
+    ) as aliases,
+    m.value:type::string as metric_type,
+    nullif(
+        (select listagg(f.value::string, ', ') from lateral flatten(input => m.value:tables) f),
+        ''
+    ) as tables,
+    m.value:metric_sql::string as metric_sql,
+    nullif(
+        (select listagg(f.value::string, ' AND ') from lateral flatten(input => m.value:filter) f),
+        ''
+    ) as filter,
+    m.value:format::string as format,
+    m.value:unit::string as unit,
+    m.value:polarity::string as polarity,
+    m.value:precision::integer as precision,
+    nullif(
+        (select listagg(f.value::string, ', ') from lateral flatten(input => m.value:tags) f),
+        ''
+    ) as tags,
+    m.value:description::string as description,
+    nullif(
+        (select listagg(f.value::string, '; ') from lateral flatten(input => m.value:example_questions) f),
+        ''
+    ) as example_questions
+from latest,
+     lateral flatten(input => _raw_record:layer:metrics) m
+
+{% endif %}
+
+{% elif has_metrics %}
+
+-- ── Legacy vars path ──────────────────────────────────────────────────────────
+-- Present during transition while client dbt_project.yml vars still exist.
+-- Remove vars (and this branch becomes unreachable) after verifying warehouse data.
 
     {% set ns = namespace(first=true) %}
     {% for model_name, metrics_list in all_metrics.items() %}
@@ -32,6 +153,7 @@
 
 {% else %}
 
+-- ── Empty result ──────────────────────────────────────────────────────────────
     {% if target.type == 'bigquery' %}
     SELECT
         CAST(NULL AS STRING) AS model,

--- a/models/sources/semantic_layers/semantic_layers.yml
+++ b/models/sources/semantic_layers/semantic_layers.yml
@@ -1,0 +1,31 @@
+version: 2
+
+sources:
+  - name: semantic_layers
+    description: >
+      Semantic layers — the "Big Beautiful Pipeline" `semantic_layers` collection.
+      A file-defined semantic layer (source of truth = a `.ts` file on the Nexus
+      master branch) projected to each client's warehouse on the BBP contract:
+      the lean envelope columns (`_convex_id`, `_row_id`, `_queued_at`,
+      `_ingested_at`, `_schema_id`, `_producer`, `_actor`) plus a `_raw_record`
+      JSON/VARIANT payload `{organization_id, layer_slug, content_hash, layer}`,
+      where `layer` nests `metrics[] / dimensions[] / organization`.
+      Append-only + change-gated: one row per layer VERSION, so
+      latest-per-(organization_id, layer_slug) is the current layer.
+    schema: >-
+      {{ var('nexus', {}).get('sources', {}).get('semantic_layers', {}).get('schema',
+      'semantic_layers_disabled_' ~ project_name) }}
+    database: >-
+      {{ var('nexus', {}).get('sources', {}).get('semantic_layers', {}).get('database', '') }}
+    tables:
+      - name: semantic_layers
+        identifier: >-
+          {{ var('nexus', {}).get('sources', {}).get('semantic_layers', {}).get('table', 'semantic_layers') }}
+        description: "Raw semantic_layers collection rows (append-only version log)."
+        columns:
+          - name: _raw_record
+            description: "JSON/VARIANT payload: {organization_id, layer_slug, content_hash, layer{metrics,dimensions,organization}}."
+          - name: _ingested_at
+            description: "When this layer version landed (latest wins per org+layer)."
+          - name: _producer
+            description: "Envelope producer (e.g. 'semantic-layers')."


### PR DESCRIPTION
## Summary

Adds the warehouse read path to `nexus_metrics_metadata` and `nexus_event_dimensions_metadata`, replacing the current `vars.nexus.metrics` / `vars.nexus.dimensions` Jinja variable approach when a client enables it.

- **New source**: `models/sources/semantic_layers/semantic_layers.yml` — points at the BBP-projected `semantic_layers` collection (same pattern as `tracking_plans.yml`)
- **`nexus_metrics_metadata`**: when `var('nexus').sources.semantic_layers.enabled = true`, reads from the warehouse source with adapter-portable JSON unnesting (BigQuery `json_query_array` + `UNNEST` / Snowflake `LATERAL FLATTEN`); falls back to the legacy var-loop for transition; zero-row empty result if neither configured
- **`nexus_event_dimensions_metadata`**: same priority logic for the `yaml_dimensions` CTE; warehouse stats + `FULL OUTER JOIN` are unchanged
- Version bump `0.2.1 → 0.2.2`

## Client configuration

To enable the warehouse path, clients add to their `dbt_project.yml`:

```yaml
vars:
  nexus:
    sources:
      semantic_layers:
        enabled: true
        schema: <BBP write schema>   # same schema as other BBP collections
        database: <warehouse db>
        table: semantic_layers
```

After verifying row counts match the old var-based output, remove `vars.nexus.metrics` and `vars.nexus.dimensions` (separate client PRs).

## Output columns

Unchanged — same column names and types as the var-based path, so all downstream consumers (LLM context, Confluence export, dashboards) are unaffected.

## Test plan

- [ ] `dbt build --select nexus_metrics_metadata nexus_event_dimensions_metadata --target dev` on a client with `semantic_layers.enabled=true` — verify row counts match what the vars produced
- [ ] Same build on a client still using vars (no `semantic_layers` configured) — verify unchanged output

🤖 Generated with [Claude Code](https://claude.com/claude-code)