### PR TITLE
Partition/cluster incremental tables + literal watermark predicates (BigQuery pruning)

### DIFF
--- a/docs/incremental-identity-resolution.md
+++ b/docs/incremental-identity-resolution.md
@@ -352,6 +352,20 @@ DAG invocation as the resolver (the default `dbt run` does).
   distinct entities/identifiers linked in one batch would under-merge (the
   next batch touching them heals it, but don't rely on that — raise the var
   if batches are huge).
+- **BigQuery pruning needs literals and a rebuild.** Watermark predicates
+  are inlined as timestamp literals fetched at render time
+  (`nexus_incremental_watermark_literal`) because BigQuery only reliably
+  prunes partitions on constants — a scalar-subquery watermark forces a
+  full scan every run. The incremental tables carry
+  `partition_by(month(_ingested_at | resolved_at_watermark))` +
+  `cluster_by(merge keys)` via the standard `nexus_bq_partition_by` /
+  `nexus_cluster_by` toggles (no-ops off BigQuery). Note dbt cannot
+  repartition an existing table in place: tables built before these configs
+  keep their old layout (and its full-scan merges) until a one-time
+  `--full-refresh` rebuilds them — the upgrade guards do NOT catch this
+  case since no columns are missing. Measured motivation: a zero-row
+  steady-state merge into the unpartitioned SRT identifiers table scanned
+  ~280 MiB.
 - **Full refresh renumbers.** By design (§2.1). Downstream systems holding
   entity_ids must treat a full refresh as an id-migration event; the log's
   new epoch is the migration record.

--- a/macros/config/nexus_incremental_enabled.sql
+++ b/macros/config/nexus_incremental_enabled.sql
@@ -44,11 +44,29 @@
    events must still enter (docs/incremental-identity-resolution.md §2.6). #}
 {% macro nexus_incremental_source_filter(column='_ingested_at') %}
   {%- if is_incremental() %}
-where {{ column }} > coalesce(
-    (select max({{ column }}) from {{ this }}),
-    cast('1970-01-01' as timestamp)
-)
+where {{ column }} > {{ nexus.nexus_incremental_watermark_literal(column) }}
   {%- endif %}
+{% endmacro %}
+
+{# Fetch max(column) from a relation (default: {{ this }}) at render time and
+   inline it as a timestamp LITERAL. BigQuery only reliably prunes partitions
+   on constant predicates -- the previous scalar-subquery watermark forced a
+   full scan of the (partitioned) table on every incremental run. The value
+   comes from the table, never the clock, so renders stay deterministic and
+   re-runs idempotent. Falls back to the epoch on empty tables and during
+   parse. #}
+{% macro nexus_incremental_watermark_literal(column, relation=none) %}
+  {%- set rel = relation if relation is not none else this -%}
+  {%- if execute -%}
+    {%- set wm = run_query("select max(" ~ column ~ ") from " ~ rel).columns[0].values()[0] -%}
+    {%- if wm is none -%}
+cast('1970-01-01' as timestamp)
+    {%- else -%}
+cast('{{ wm }}' as timestamp)
+    {%- endif -%}
+  {%- else -%}
+cast('1970-01-01' as timestamp)
+  {%- endif -%}
 {% endmacro %}
 
 {# Upgrade guard for enabling incremental mode over an EXISTING deployment.

--- a/macros/entity-resolution/create_identifier_edges.sql
+++ b/macros/entity-resolution/create_identifier_edges.sql
@@ -29,10 +29,7 @@ with unpivoted as (
   -- mark. Both endpoints of an edge come from the same event (same edge_id),
   -- so they always arrive in the same batch -- filtering the unpivoted rows
   -- filters whole edges, never half of one.
-  where _ingested_at > coalesce(
-      (select max(_ingested_at) from {{ this }}),
-      cast('1970-01-01' as timestamp)
-  )
+  where _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
   {% endif %}
 ),
 

--- a/macros/entity-resolution/incremental_resolve_identifiers.sql
+++ b/macros/entity-resolution/incremental_resolve_identifiers.sql
@@ -46,29 +46,31 @@
    keep their first sighting's _ingested_at), so probe the delta with one
    cheap count and emit a schema-preserving empty change-set when there is
    nothing to do. #}
+{# The watermark is fetched once at render time and inlined as a literal
+   everywhere (probe, delta filters): BigQuery only reliably prunes
+   partitions on constant predicates, and a single read also guarantees the
+   probe and the body agree on the cutoff. #}
+{% set wm_literal = nexus.nexus_incremental_watermark_literal('resolved_at_watermark') %}
 {% set delta_probe_sql %}
   select count(*) from {{ ref(identifiers_table) }} ei
   where ei.entity_type = '{{ entity_type }}'
     and ei.identifier_value is not null
-    and ei._ingested_at > (
-      select coalesce(max(resolved_at_watermark), cast('1970-01-01' as timestamp))
-      from {{ this }}
-    )
+    and ei._ingested_at > {{ wm_literal }}
 {% endset %}
 {% if execute %}
   {% set delta_rows = run_query(delta_probe_sql).columns[0].values()[0] %}
   {% if delta_rows == 0 %}
 select * from {{ this }} where 1 = 0
   {% else %}
-{{ nexus_incremental_resolve_identifiers_body(entity_type, identifiers_table, edges_table, max_iterations) }}
+{{ nexus_incremental_resolve_identifiers_body(entity_type, identifiers_table, edges_table, max_iterations, wm_literal) }}
   {% endif %}
 {% else %}
-{{ nexus_incremental_resolve_identifiers_body(entity_type, identifiers_table, edges_table, max_iterations) }}
+{{ nexus_incremental_resolve_identifiers_body(entity_type, identifiers_table, edges_table, max_iterations, wm_literal) }}
 {% endif %}
 {% endmacro %}
 
 
-{% macro nexus_incremental_resolve_identifiers_body(entity_type, identifiers_table, edges_table, max_iterations=5) %}
+{% macro nexus_incremental_resolve_identifiers_body(entity_type, identifiers_table, edges_table, max_iterations=5, wm_literal="cast('1970-01-01' as timestamp)") %}
 
 with prior_state as (
   select
@@ -78,17 +80,12 @@ with prior_state as (
   from {{ this }}
 ),
 
-prior_watermark as (
-  select coalesce(max(resolved_at_watermark), cast('1970-01-01' as timestamp)) as wm
-  from {{ this }}
-),
-
 delta_identifiers as (
   select ei.*
   from {{ ref(identifiers_table) }} ei
   where ei.entity_type = '{{ entity_type }}'
     and ei.identifier_value is not null
-    and ei._ingested_at > (select wm from prior_watermark)
+    and ei._ingested_at > {{ wm_literal }}
 ),
 
 batch_watermark as (
@@ -100,7 +97,7 @@ delta_edges as (
   from {{ ref(edges_table) }} e
   where e.entity_type_a = '{{ entity_type }}'
     and e.entity_type_b = '{{ entity_type }}'
-    and e._ingested_at > (select wm from prior_watermark)
+    and e._ingested_at > {{ wm_literal }}
 ),
 
 -- Contraction: every distinct identifier in the batch becomes a graph node.

--- a/macros/event-log/process_entity_identifiers.sql
+++ b/macros/event-log/process_entity_identifiers.sql
@@ -122,10 +122,7 @@
         -- Incremental mode: only rows ingested after the high-water mark.
         -- Watermark is on ingestion time, never occurred_at -- late-arriving
         -- events (old occurred_at, new _ingested_at) must still enter.
-        where _ingested_at > coalesce(
-            (select max(_ingested_at) from {{ this }}),
-            cast('1970-01-01' as timestamp)
-        )
+        where _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
         -- Batch-level dedup: warehouse merges reject duplicate unique_key
         -- values within one batch.
         qualify row_number() over (

--- a/models/intermediate/entities/nexus_entity_identifiers.sql
+++ b/models/intermediate/entities/nexus_entity_identifiers.sql
@@ -1,5 +1,7 @@
 {{ config(
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_identifier_id']),
     unique_key='entity_identifier_id',
     on_schema_change='append_new_columns',
     tags=['identity-resolution', 'event-processing', 'entities']

--- a/models/intermediate/identity-resolution/nexus_entity_identifiers_edges.sql
+++ b/models/intermediate/identity-resolution/nexus_entity_identifiers_edges.sql
@@ -1,5 +1,7 @@
 {{ config(
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['edge_uniqueness_hash']),
     unique_key='edge_uniqueness_hash',
     on_schema_change='append_new_columns',
     tags=['identity-resolution', 'entities']

--- a/models/intermediate/identity-resolution/nexus_resolution_log.sql
+++ b/models/intermediate/identity-resolution/nexus_resolution_log.sql
@@ -1,6 +1,8 @@
 {{ config(
     enabled=nexus.nexus_incremental_enabled(),
     materialized='incremental',
+    partition_by=nexus.nexus_bq_partition_by('resolved_at_watermark', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_type', 'resolution_reason']),
     full_refresh=false,
     tags=['identity-resolution'],
 ) }}
@@ -54,8 +56,5 @@ from changes
 -- reobserved-only batches.
 where resolution_reason != 'reobserved'
 {% if is_incremental() %}
-  and resolved_at_watermark > coalesce(
-    (select max(resolved_at_watermark) from {{ this }}),
-    cast('1970-01-01' as timestamp)
-)
+  and resolved_at_watermark > {{ nexus.nexus_incremental_watermark_literal('resolved_at_watermark') }}
 {% endif %}

--- a/models/intermediate/identity-resolution/types/nexus_resolved_group_identifiers.sql
+++ b/models/intermediate/identity-resolution/types/nexus_resolved_group_identifiers.sql
@@ -1,5 +1,7 @@
 {{ config(
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('resolved_at_watermark', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['identifier_type', 'identifier_value']),
     unique_key=['identifier_type', 'identifier_value'],
     on_schema_change='append_new_columns',
     tags=['identity-resolution', 'groups'],

--- a/models/intermediate/identity-resolution/types/nexus_resolved_person_identifiers.sql
+++ b/models/intermediate/identity-resolution/types/nexus_resolved_person_identifiers.sql
@@ -1,5 +1,7 @@
 {{ config(
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('resolved_at_watermark', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['identifier_type', 'identifier_value']),
     unique_key=['identifier_type', 'identifier_value'],
     on_schema_change='append_new_columns',
     tags=['identity-resolution', 'persons'],

--- a/models/sources/gmail/gmail_entity_identifiers.sql
+++ b/models/sources/gmail/gmail_entity_identifiers.sql
@@ -1,6 +1,8 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_identifier_id']),
     unique_key='entity_identifier_id',
     on_schema_change='append_new_columns',
     tags=['nexus', 'entity_identifiers', 'gmail']

--- a/models/sources/gmail/gmail_entity_identifiers.sql
+++ b/models/sources/gmail/gmail_entity_identifiers.sql
@@ -32,4 +32,3 @@ qualify row_number() over (
     order by _ingested_at desc
 ) = 1
 {% endif %}
-order by occurred_at desc

--- a/models/sources/gmail/gmail_entity_traits.sql
+++ b/models/sources/gmail/gmail_entity_traits.sql
@@ -41,4 +41,3 @@ QUALIFY ROW_NUMBER() OVER (
     ORDER BY occurred_at DESC, _ingested_at DESC
 ) = 1
 
-ORDER BY occurred_at DESC

--- a/models/sources/gmail/gmail_entity_traits.sql
+++ b/models/sources/gmail/gmail_entity_traits.sql
@@ -1,6 +1,8 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_trait_id']),
     unique_key='entity_trait_id',
     on_schema_change='append_new_columns',
     tags=['nexus', 'entity_traits', 'gmail']

--- a/models/sources/gmail/gmail_events.sql
+++ b/models/sources/gmail/gmail_events.sql
@@ -31,4 +31,3 @@ qualify row_number() over (
     order by _ingested_at desc
 ) = 1
 {% endif %}
-order by occurred_at desc

--- a/models/sources/gmail/gmail_events.sql
+++ b/models/sources/gmail/gmail_events.sql
@@ -1,6 +1,8 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_id']),
     unique_key='event_id',
     on_schema_change='append_new_columns',
     tags=['nexus', 'events', 'gmail']

--- a/models/sources/gmail/gmail_relationship_declarations.sql
+++ b/models/sources/gmail/gmail_relationship_declarations.sql
@@ -1,6 +1,8 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['relationship_declaration_id']),
     unique_key='relationship_declaration_id',
     on_schema_change='append_new_columns',
     tags=['nexus', 'relationship_declarations', 'gmail']

--- a/models/sources/gmail/gmail_relationship_declarations.sql
+++ b/models/sources/gmail/gmail_relationship_declarations.sql
@@ -30,4 +30,3 @@ qualify row_number() over (
     order by _ingested_at desc
 ) = 1
 {% endif %}
-order by occurred_at desc

--- a/models/sources/google_calendar/google_calendar_entity_identifiers.sql
+++ b/models/sources/google_calendar/google_calendar_entity_identifiers.sql
@@ -1,6 +1,8 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_identifier_id']),
     unique_key='entity_identifier_id',
     on_schema_change='append_new_columns',
     tags=['nexus', 'entity_identifiers', 'google_calendar']

--- a/models/sources/google_calendar/google_calendar_entity_identifiers.sql
+++ b/models/sources/google_calendar/google_calendar_entity_identifiers.sql
@@ -31,4 +31,3 @@ qualify row_number() over (
     order by _ingested_at desc
 ) = 1
 {% endif %}
-order by occurred_at desc

--- a/models/sources/google_calendar/google_calendar_entity_traits.sql
+++ b/models/sources/google_calendar/google_calendar_entity_traits.sql
@@ -31,4 +31,3 @@ qualify row_number() over (
     order by occurred_at desc, _ingested_at desc
 ) = 1
 {% endif %}
-order by occurred_at desc

--- a/models/sources/google_calendar/google_calendar_entity_traits.sql
+++ b/models/sources/google_calendar/google_calendar_entity_traits.sql
@@ -1,6 +1,8 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_trait_id']),
     unique_key='entity_trait_id',
     on_schema_change='append_new_columns',
     tags=['nexus', 'entity_traits', 'google_calendar']

--- a/models/sources/google_calendar/google_calendar_events.sql
+++ b/models/sources/google_calendar/google_calendar_events.sql
@@ -31,4 +31,3 @@ qualify row_number() over (
     order by _ingested_at desc
 ) = 1
 {% endif %}
-order by occurred_at desc

--- a/models/sources/google_calendar/google_calendar_events.sql
+++ b/models/sources/google_calendar/google_calendar_events.sql
@@ -1,6 +1,8 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_id']),
     unique_key='event_id',
     on_schema_change='append_new_columns',
     tags=['nexus', 'events', 'google_calendar']

--- a/models/sources/google_calendar/google_calendar_relationship_declarations.sql
+++ b/models/sources/google_calendar/google_calendar_relationship_declarations.sql
@@ -31,4 +31,3 @@ qualify row_number() over (
     order by _ingested_at desc
 ) = 1
 {% endif %}
-order by occurred_at desc

--- a/models/sources/google_calendar/google_calendar_relationship_declarations.sql
+++ b/models/sources/google_calendar/google_calendar_relationship_declarations.sql
@@ -1,6 +1,8 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
     materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['relationship_declaration_id']),
     unique_key='relationship_declaration_id',
     on_schema_change='append_new_columns',
     tags=['nexus', 'relationship_declarations', 'google_calendar']


### PR DESCRIPTION
Follow-up to the v0.12.1 rollout. The SRT prod A/B showed incremental runs processing **+15% more bytes** than full rebuilds: every incremental model paid a watermark probe plus a MERGE that scans the whole unpartitioned target (a zero-row steady-state merge into `nexus_entity_identifiers` scanned ~280 MiB).

Two changes, riding the existing `nexus_bq_partition_by` / `nexus_cluster_by` machinery (no-ops off BigQuery; DuckDB harness green):

1. **Literal watermark predicates** — `nexus_incremental_watermark_literal` fetches `max(watermark)` at render time and inlines it as a constant; BigQuery only reliably prunes partitions on constants. Single fetch per model; the resolver threads one value through probe + body so both agree on the cutoff. Deterministic (value from the table, never the clock).
2. **`partition_by(month(_ingested_at | resolved_at_watermark))` + `cluster_by(merge keys)`** on the 13 incremental package models (core ER chain, resolution log, gmail/gcal finals). Also drops the cosmetic trailing `ORDER BY` on the finals — BigQuery refuses to create partitioned tables from ORDER BY queries, and the global sort was waste regardless.

**Measured on SRT dev (steady-state run, zero-row deltas), before → after:**

| model | before | after |
|---|---|---|
| nexus_entity_identifiers | 278.9 MiB | 79.7 MiB |
| gmail_entity_identifiers | 179.4 MiB | 29.4 MiB |
| google_calendar_entity_identifiers | 161.3 MiB | 25.1 MiB |
| gmail_events | 78.6 MiB | 3.5 MiB |
| **all 26 incremental models** | **1,040 MiB** | **199 MiB (−81%)** |

**Upgrade note (docs §4.7):** dbt cannot repartition an existing table in place — the pruning materializes only after a one-time `--full-refresh` of the incremental models, and the upgrade guards do NOT catch this case (no columns are missing). Suggest tagging as **v0.13.0** given the rollout step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)