### PR TITLE
guard: block client data/analyses from the public dbt-nexus repo

### DIFF
--- a/.cursor/rules/context.mdc
+++ b/.cursor/rules/context.mdc
@@ -13,3 +13,11 @@ When working in the dbt-nexus package, reference these for context:
 - How to perform analysis: app/content/docs/how-to/perform-analysis.mdx
 - Conventions: app/content/docs/ai-context/conventions.mdx
 - Repo map: app/content/docs/ai-context/repo-map.mdx
+
+## ⚠️ This is a PUBLIC repo — never commit client data here
+`dbt-nexus` is public. Do not commit customer/client data or client-specific
+analyses — including anywhere under `analyses/` (which must stay empty, only
+`.gitkeep`). Client analyses, experiment results, revenue/lead figures,
+internal warehouse table names, and any confidential data belong in the
+client's PRIVATE repo, or are run directly against the warehouse. A CI check
+(`.github/workflows/guard-analyses.yml`) enforces this. See `CLAUDE.md`.

--- a/.github/workflows/guard-analyses.yml
+++ b/.github/workflows/guard-analyses.yml
@@ -1,0 +1,39 @@
+name: Guard — no client data in analyses/
+
+# dbt-nexus is a PUBLIC framework repo. `analyses/` must stay empty (only
+# .gitkeep). Client-specific analyses / customer confidential data must never
+# be committed here — they belong in the client's private repo or are run
+# directly against the warehouse. This check fails loudly if anything else
+# shows up under analyses/, on both pull_request and push.
+#
+# Note: on pull_request this runs *after* the PR is opened, so it is a
+# detective/blocking gate, not a preventive one — the authoring-side rule in
+# CLAUDE.md is what stops the file being created in the first place.
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  no-client-analyses:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if analyses/ contains anything but .gitkeep
+        run: |
+          set -euo pipefail
+          offending=$(git ls-files analyses/ | grep -v '^analyses/\.gitkeep$' || true)
+          if [ -n "$offending" ]; then
+            echo "::error::Client analyses / customer data must never be committed to the public dbt-nexus repo."
+            echo "Only analyses/.gitkeep is permitted. Offending files:"
+            echo "$offending" | sed 's/^/  - /'
+            echo ""
+            echo "Move client-specific analyses to the client's PRIVATE repo, or run them"
+            echo "directly against the warehouse (e.g. the Nexus MCP query_warehouse tool)."
+            echo "See CLAUDE.md for the rule."
+            exit 1
+          fi
+          echo "OK: analyses/ contains only .gitkeep."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# dbt-nexus — agent instructions
+
+`dbt-nexus` is the **public**, open-source Nexus dbt framework package.
+Treat everything committed here as world-readable.
+
+## Never commit client data or client-specific analyses to this repo
+
+This is a **public** repository. Do **not** add customer/client data, results,
+or client-specific analyses here — including anywhere under `analyses/`.
+
+- `analyses/` must stay **empty**; it holds only `.gitkeep`. A CI check
+  (`.github/workflows/guard-analyses.yml`) fails any commit that adds other
+  files there.
+- Client-specific analysis SQL/markdown, experiment results, lead/revenue
+  figures, internal warehouse table or schema names, stakeholder names, and any
+  customer confidential data belong in the **client's private repo**, or are
+  run directly against the warehouse (e.g. via the Nexus MCP `query_warehouse`
+  tool) — never persisted to this package.
+- Only generic, non-client framework code (models, macros, tests, docs) belongs
+  in `dbt-nexus`.
+
+If you were asked to produce a client analysis, write it in the client's
+**private** repository, not here. When in doubt, do not commit — ask first.


### PR DESCRIPTION
## Why


This adds guardrails so we don't add client sensitive data to analyses.

## What

- **`.github/workflows/guard-analyses.yml`** — CI on `pull_request` **and**
  `push`. Fails loudly if anything but `.gitkeep` appears under `analyses/`.
  This repo's `analyses/` is meant to be empty; client analyses belong in the
  client's private repo or run against the warehouse directly.
- **`CLAUDE.md`** (new) — repo-level agent instructions: this is a public repo,
  never commit client data / client-specific analyses here. This is the
  *preventive* layer — it stops an agent from creating the file at all.
- **`.cursor/rules/context.mdc`** — same warning for the Cursor authoring path.

## Honest limitation

CI on `pull_request` runs *after* the PR is opened, so the content is briefly
public before the check fails — it's a **detective/blocking gate, not full
prevention**. The `CLAUDE.md` / Cursor rules are what actually prevent the file
being authored in the first place. Together: agents shouldn't create it; if one
does, CI catches it fast and blocks the merge.