### PR TITLE
fix(google_calendar): derive occurred_at from instance_start, not start_time

### DIFF
--- a/models/sources/google_calendar/intermediate/google_calendar_event_events.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_event_events.sql
@@ -7,7 +7,7 @@
 -- Extract calendar events from normalized google_calendar_events
 SELECT
     {{ nexus.create_nexus_id('event', ['event_id']) }} as event_id,
-    start_time as occurred_at,
+    instance_start as occurred_at,
     CASE 
         WHEN has_external_attendees THEN 'external_meeting'
         ELSE 'internal_meeting'

--- a/models/sources/google_calendar/intermediate/google_calendar_event_relationship_declarations.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_event_relationship_declarations.sql
@@ -13,7 +13,7 @@ participants_with_nexus_event_id AS (
     SELECT
         {{ nexus.create_nexus_id('event', ['event_id']) }} as nexus_event_id,
         event_id,
-        start_time,
+        instance_start,
         email,
         domain,
         role,
@@ -26,7 +26,7 @@ participants_with_domains AS (
     SELECT
         nexus_event_id,
         event_id,
-        start_time,
+        instance_start,
         email as entity_a_identifier,
         domain as entity_b_identifier,
         role,
@@ -42,7 +42,7 @@ participants_with_domains AS (
 relationships AS (
     SELECT DISTINCT
         nexus_event_id as event_id,
-        start_time as occurred_at,
+        instance_start as occurred_at,
         entity_a_identifier,
         'email' as entity_a_identifier_type,
         'person' as entity_a_type,

--- a/models/sources/google_calendar/intermediate/google_calendar_group_identifiers.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_group_identifiers.sql
@@ -13,7 +13,7 @@ participants_with_nexus_event_id AS (
     SELECT
         {{ nexus.create_nexus_id('event', ['event_id']) }} as nexus_event_id,
         event_id,
-        start_time,
+        instance_start,
         _ingested_at,
         domain,
         role
@@ -25,7 +25,7 @@ domains_filtered AS (
     SELECT DISTINCT
         nexus_event_id,
         event_id,
-        start_time,
+        instance_start,
         _ingested_at,
         domain,
         role
@@ -37,14 +37,14 @@ domains_filtered AS (
 -- Create domain identifiers
 domain_identifiers AS (
     SELECT
-        {{ nexus.create_nexus_id('entity_identifier', ['nexus_event_id', 'domain', "'group'", 'role', 'start_time']) }} as entity_identifier_id,
+        {{ nexus.create_nexus_id('entity_identifier', ['nexus_event_id', 'domain', "'group'", 'role', 'instance_start']) }} as entity_identifier_id,
         nexus_event_id as event_id,
         {{ nexus.create_nexus_id('edge', ['nexus_event_id', 'domain', "'group'", 'role']) }} as edge_id,
         'group' as entity_type,
         'domain' as identifier_type,
         domain as identifier_value,
         'google_calendar' as source,
-        start_time as occurred_at,
+        instance_start as occurred_at,
         _ingested_at,
         role
     FROM domains_filtered
@@ -54,14 +54,14 @@ domain_identifiers AS (
 -- Add redirected domains (www. versions)
 redirected_domains AS (
     SELECT
-        {{ nexus.create_nexus_id('entity_identifier', ['nexus_event_id', nexus.redirected_domain('domain'), "'group'", 'role', 'start_time']) }} as entity_identifier_id,
+        {{ nexus.create_nexus_id('entity_identifier', ['nexus_event_id', nexus.redirected_domain('domain'), "'group'", 'role', 'instance_start']) }} as entity_identifier_id,
         nexus_event_id as event_id,
         {{ nexus.create_nexus_id('edge', ['nexus_event_id', nexus.redirected_domain('domain'), "'group'", 'role']) }} as edge_id,
         'group' as entity_type,
         'domain' as identifier_type,
         {{ nexus.redirected_domain('domain') }} as identifier_value,
         'google_calendar' as source,
-        start_time as occurred_at,
+        instance_start as occurred_at,
         _ingested_at,
         role
     FROM domains_filtered

--- a/models/sources/google_calendar/intermediate/google_calendar_group_traits.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_group_traits.sql
@@ -13,7 +13,7 @@ participants_with_nexus_event_id AS (
     SELECT
         {{ nexus.create_nexus_id('event', ['event_id']) }} as nexus_event_id,
         event_id,
-        start_time,
+        instance_start,
         _ingested_at,
         domain
     FROM participants
@@ -24,7 +24,7 @@ domains_filtered AS (
     SELECT DISTINCT
         nexus_event_id,
         event_id,
-        start_time,
+        instance_start,
         _ingested_at,
         domain
     FROM participants_with_nexus_event_id
@@ -44,7 +44,7 @@ domain_traits AS (
         'domain' as trait_name,
         domain as trait_value,
         'google_calendar' as source,
-        start_time as occurred_at,
+        instance_start as occurred_at,
         _ingested_at
     FROM domains_filtered
     WHERE domain IS NOT NULL

--- a/models/sources/google_calendar/intermediate/google_calendar_person_identifiers.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_person_identifiers.sql
@@ -14,7 +14,7 @@ participants_with_event_id AS (
         {{ nexus.create_nexus_id('event', ['event_id']) }} as nexus_event_id,
         event_id,
         email,
-        start_time,
+        instance_start,
         _ingested_at,
         role
     FROM participants
@@ -30,7 +30,7 @@ identifiers AS (
         'email' as identifier_type,
         email as identifier_value,
         'google_calendar' as source,
-        start_time as occurred_at,
+        instance_start as occurred_at,
         _ingested_at,
         role
     FROM participants_with_event_id

--- a/models/sources/google_calendar/intermediate/google_calendar_person_traits.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_person_traits.sql
@@ -15,7 +15,7 @@ participants_with_event_id AS (
         event_id,
         email,
         name,
-        start_time,
+        instance_start,
         _ingested_at,
         role
     FROM participants
@@ -32,7 +32,7 @@ name_traits AS (
         'name' as trait_name,
         name as trait_value,
         'google_calendar' as source,
-        start_time as occurred_at,
+        instance_start as occurred_at,
         _ingested_at
     FROM participants_with_event_id
     WHERE name IS NOT NULL
@@ -49,7 +49,7 @@ name_traits AS (
         'email' as trait_name,
         email as trait_value,
         'google_calendar' as source,
-        start_time as occurred_at,
+        instance_start as occurred_at,
         _ingested_at
     FROM participants_with_event_id
     WHERE email IS NOT NULL


### PR DESCRIPTION
## Problem
Slide Rule Tech's dbt build (and any calendar-connected client) fails: `unique_nexus_entity_participants_entity_participant_id`.

Recurring calendar events can surface the **same** nexus `event_id` (`ical_uid | instance_start`) with **divergent `start_time`** — a rescheduled instance, or the same meeting synced across multiple accounts, reports a different `start.dateTime` (e.g. a weekly 1:1 shows 13:00 in one copy and 13:30 in another).

`entity_participant_id = hash(event_id, entity_id, role)` (no time), and `nexus_entity_participants` does `GROUP BY event_id, entity_id, role, occurred_at`. The divergent `occurred_at` emits **two rows with the same `entity_participant_id`** → uniqueness test fails → dbt **SKIPs the whole downstream nexus spine** (entities, relationships, states, contacts), leaving it stale.

## Fix
`instance_start` (`COALESCE(originalStartTime, start.dateTime, start.date)`) is **stable per `event_id`** — it's the event-id key. Derive **`occurred_at` from `instance_start`** instead of the per-copy `start_time` across the `google_calendar` intermediate models (identifiers, traits, relationship declarations, events). The calendar id fields that embed the event time now use `instance_start` too (stable across reschedules/cross-account copies).

One event → one `occurred_at` → the participants `GROUP BY` collapses to one row → uniqueness holds. The events model keeps its real `start_time` column; only `occurred_at` changes. No change for non-recurring events (`instance_start == start_time`).

## Release
Cutting `v0.12.3` after merge; SRT's `packages.yml` bumps `v0.12.2 → v0.12.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTw4BierE2KJ6w4dwkbkqe