### PR TITLE
fix(metadata): Snowflake array_to_string instead of correlated flatten subquery

### DIFF
--- a/models/metadata/nexus_event_dimensions_metadata.sql
+++ b/models/metadata/nexus_event_dimensions_metadata.sql
@@ -69,18 +69,9 @@ WITH yaml_dimensions AS (
             initcap(replace(d.value:name::string, '_', ' '))
         ) as label,
         d.value:description::string as description,
-        nullif(
-            (select listagg(f.value::string, ', ') from lateral flatten(input => d.value:aliases) f),
-            ''
-        ) as aliases,
-        nullif(
-            (select listagg(f.value::string, ', ') from lateral flatten(input => d.value:tags) f),
-            ''
-        ) as tags,
-        nullif(
-            (select listagg(f.value::string, '; ') from lateral flatten(input => d.value:example_questions) f),
-            ''
-        ) as example_questions
+        nullif(array_to_string(d.value:aliases::array, ', '), '') as aliases,
+        nullif(array_to_string(d.value:tags::array, ', '), '') as tags,
+        nullif(array_to_string(d.value:example_questions::array, '; '), '') as example_questions
     from latest,
          lateral flatten(input => _raw_record:layer:dimensions) d
     {% endif %}

--- a/models/metadata/nexus_metrics_metadata.sql
+++ b/models/metadata/nexus_metrics_metadata.sql
@@ -89,33 +89,18 @@ select
     m.value:model::string as model,
     m.value:name::string as metric_name,
     m.value:label::string as label,
-    nullif(
-        (select listagg(f.value::string, ', ') from lateral flatten(input => m.value:aliases) f),
-        ''
-    ) as aliases,
+    nullif(array_to_string(m.value:aliases::array, ', '), '') as aliases,
     m.value:type::string as metric_type,
-    nullif(
-        (select listagg(f.value::string, ', ') from lateral flatten(input => m.value:tables) f),
-        ''
-    ) as tables,
+    nullif(array_to_string(m.value:tables::array, ', '), '') as tables,
     m.value:metric_sql::string as metric_sql,
-    nullif(
-        (select listagg(f.value::string, ' AND ') from lateral flatten(input => m.value:filter) f),
-        ''
-    ) as filter,
+    nullif(array_to_string(m.value:filter::array, ' AND '), '') as filter,
     m.value:format::string as format,
     m.value:unit::string as unit,
     m.value:polarity::string as polarity,
     m.value:precision::integer as precision,
-    nullif(
-        (select listagg(f.value::string, ', ') from lateral flatten(input => m.value:tags) f),
-        ''
-    ) as tags,
+    nullif(array_to_string(m.value:tags::array, ', '), '') as tags,
     m.value:description::string as description,
-    nullif(
-        (select listagg(f.value::string, '; ') from lateral flatten(input => m.value:example_questions) f),
-        ''
-    ) as example_questions
+    nullif(array_to_string(m.value:example_questions::array, '; '), '') as example_questions
 from latest,
      lateral flatten(input => _raw_record:layer:metrics) m
 


### PR DESCRIPTION
## Problem

Prod dbt build for cinch (and any Snowflake client on the warehouse `semantic_layers` path) fails:

```
002031 (42601): SQL compilation error:
Unsupported subquery type cannot be evaluated
```

in both `nexus_metrics_metadata` and `nexus_event_dimensions_metadata`. Introduced by the warehouse-path change in #… (yesterday, shipped in v0.11.12).

## Cause

The Snowflake branch built each delimited array field with a **correlated** scalar subquery whose `FLATTEN` input references the outer flatten row:

```sql
(select listagg(f.value::string, ', ')
 from lateral flatten(input => m.value:aliases) f)
```

Snowflake can't evaluate that subquery shape.

## Fix

Use the native, non-correlated `array_to_string(m.value:aliases::array, ', ')`. Same for `tables`, `filter`, `tags`, `example_questions` (metrics) and `aliases`, `tags`, `example_questions` (dimensions). BigQuery branch untouched.

Verified against cinch's Snowflake warehouse: identical unquoted output, empty array → `''` (→ `nullif` → null), null → null.

## Follow-up (not in this PR)

Cut **v0.11.13** and bump `packages.yml` in the three affected Snowflake clients pinned to v0.11.12: **cinch, go-koala, sendowl**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)