### PR TITLE
fix(permissions): nexus_auth_identities tolerates missing email column

### DIFF
--- a/models/core/nexus_auth_identities.sql
+++ b/models/core/nexus_auth_identities.sql
@@ -6,10 +6,25 @@
   Maps an authenticated session subject (typically an email) to a person
   entity_id by lowercase-email match on nexus_entities.
 
+  The default requires an `email` column on nexus_entities, which only
+  exists when the project configures an `email` trait on person entities.
+  Projects without that trait get an empty stub matching the contract
+  columns — they still build, just with zero rows (no email-based auth
+  identities). Add the email trait, or override this model at the project
+  level, to populate it.
+
   Clients that need alias support, manual overrides, or service-account
   mappings should create a project-level model with the same name to
   override this default.
 #}
+
+{% set entity_columns = [] %}
+{% if execute %}
+    {% set entity_columns = adapter.get_columns_in_relation(ref('nexus_entities'))
+        | map(attribute='name') | map('lower') | list %}
+{% endif %}
+
+{% if 'email' in entity_columns %}
 
 with people as (
     select
@@ -31,3 +46,22 @@ select
     true as is_active,
     established_at
 from people
+
+{% else %}
+
+-- nexus_entities has no `email` column for this project's trait config →
+-- no email-based auth identities. Empty stub with the full contract column
+-- shape. The `where 1 = 0` filter needs a FROM in BigQuery and Snowflake, so
+-- we select from a one-row dummy and immediately filter it out.
+select
+    cast(null as {{ dbt.type_string() }}) as auth_identity_id,
+    cast(null as {{ dbt.type_string() }}) as auth_provider,
+    cast(null as {{ dbt.type_string() }}) as auth_subject,
+    cast(null as {{ dbt.type_string() }}) as entity_id,
+    cast(null as {{ dbt.type_string() }}) as match_method,
+    cast(false as boolean) as is_active,
+    cast(null as timestamp) as established_at
+from (select 1) _empty_auth_identities_stub
+where 1 = 0
+
+{% endif %}


### PR DESCRIPTION
## Problem

sendowl's prod dbt build fails on `nexus_auth_identities`:

```
Database Error in model nexus_auth_identities (models/core/nexus_auth_identities.sql)
  Unrecognized name: email
```

The default model does `lower(email)` from `nexus_entities`, but the `email` column only exists when a project configures an `email` trait on person entities. sendowl's trait config doesn't surface one, so the model won't compile. (Pre-existing — failing since the model landed in #70, independent of the v0.13.0 metadata fix.)

## Fix

Guard with `adapter.get_columns_in_relation(ref('nexus_entities'))`: if there's no `email` column, emit an empty stub with the full contract column shape — same `cast(null as {{ dbt.type_string() }}) … from (select 1) … where 1 = 0` pattern already used by the sibling `nexus_scopes`. Projects that **do** expose `email` are unchanged.

Result: projects without an email trait build the view with zero rows (no email-based auth identities) instead of erroring. They can add the email trait, or override the model at the project level, to populate it.

Verified `dbt parse` clean against sendowl. Empty-stub SQL is identical to `nexus_scopes`, which already builds on sendowl's BigQuery.

## Follow-up (not in this PR)

Cut **v0.13.1** and bump **sendowl** (`slide-rule-tech/sendowl-nexus`, only client currently red on this) from v0.13.0 → v0.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)