### PR TITLE
fix(permissions): declare nexus_entities dep in nexus_auth_identities

### DIFF
--- a/models/core/nexus_auth_identities.sql
+++ b/models/core/nexus_auth_identities.sql
@@ -18,6 +18,12 @@
   override this default.
 #}
 
+{#
+  Both ref('nexus_entities') uses below live inside conditional blocks, so
+  dbt can't statically infer the dependency — declare it explicitly.
+#}
+-- depends_on: {{ ref('nexus_entities') }}
+
 {% set entity_columns = [] %}
 {% if execute %}
     {% set entity_columns = adapter.get_columns_in_relation(ref('nexus_entities'))


### PR DESCRIPTION
## Problem

v0.13.1 (#95) wrapped both `ref('nexus_entities')` calls in `nexus_auth_identities` inside conditional blocks (the `{% if execute %}` guard and the has-email branch). dbt's static dependency inference (runs with `execute=False`, so neither ref renders) then fails:

```
Compilation Error in model nexus_auth_identities
  dbt was unable to infer all dependencies for the model "nexus_auth_identities".
  This typically happens when ref() is placed within a conditional block.
```

`dbt parse` didn't catch this, but `dbt build`/`dbt run` does — so it would break the CI build. Caught it via a dev build before it shipped to prod.

## Fix

Add the dbt-sanctioned hint:

```sql
-- depends_on: {{ ref('nexus_entities') }}
```

Emits no SQL; just registers the dependency explicitly.

## Verified

`dbt build --select nexus_auth_identities --target dev` on sendowl → view creates, all 7 contract tests pass (empty stub, since sendowl has no email trait).

## Follow-up

Cut **v0.13.2** and repoint the open sendowl bump PR (#17) from v0.13.1 → v0.13.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)