### PR TITLE
v0.13.0: incremental source layers + core event log

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,7 +2,7 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: "nexus"
-version: "0.2.2"
+version: "0.13.0"
 config-version: 2
 
 # This setting configures which "profile" dbt uses for this project.

--- a/docs/incremental-identity-resolution.md
+++ b/docs/incremental-identity-resolution.md
@@ -471,7 +471,72 @@ supported via `install_duckdb_compat`); a thin nightly cross-adapter smoke
 run on BigQuery/Snowflake covers dialect quirks the algorithm's plain joins
 mostly avoid.
 
-## 7. Future work
+## 7. v0.13: incremental source layers + core event log
+
+v0.12 made identity resolution incremental; v0.13 extends the same watermark
+discipline to everything around it. The package is now **incremental-native**:
+converted models are written the clean way (no trailing ORDER BYs, watermark
+columns emitted unconditionally); `nexus.incremental.enabled` remains only as
+the materialization switch and the ER-mode switch. **Upgrade contract:** a
+client bumping to v0.13 runs one `--full-refresh` (the upgrade guards turn any
+missed model into a loud error naming the fix).
+
+### 7.1 Append-class conversions
+
+Per-row source models (gmail/gcal normalized + intermediates) follow the
+finals recipe verbatim: `nexus_incremental_materialization()` + `unique_key` +
+`nexus_incremental_upgrade_guard` + a single `_ingested_at >` watermark filter
+in the first CTE that reads the upstream + batch-scoped dedup. One shared
+watermark literal must filter EVERY upstream read in the model (see
+`gmail_messages_by_account`, which filters both its message scan and its
+same-grain participant summary with one literal).
+
+### 7.2 Touched-group rollups
+
+GROUP BY models (`gmail_threads_by_account`, `gmail_messages`,
+`gmail_thread_participants`, …) can't append: a new child invalidates its
+whole group, and the rollup's own `_ingested_at` is MIN/MAX of the group.
+Pattern (macros in `nexus_incremental_touched_groups.sql`;
+`gmail_threads_by_account` is the reference conversion):
+
+1. every rollup emits `_watermark_ingested_at = MAX(child _ingested_at)` per
+   group — the reliable cursor;
+2. incremental runs compute the distinct touched group keys (upstream rows
+   past the cursor), widened where group attributes route through other
+   rollups (`gmail_messages` unions in ALL messages of touched threads);
+3. the unchanged aggregation runs over full upstream inner-joined to the
+   touched keys; dbt merges on the OUTPUT-grain unique key. No delete leg:
+   children are append-only, so groups only grow. Known caveat: a
+   late-arriving thread root re-keys its group — the old-key row lingers
+   until the next full refresh.
+
+**Rollup-child clock rule:** any model consuming a rollup must use the
+rollup's `_watermark_ingested_at` as its batch clock and re-stamp its own
+`_ingested_at` from it (`gmail_thread_events` — this also fixed a live v0.12
+bug where thread events froze at first sight).
+
+### 7.3 Core event log
+
+- `nexus_events`, `nexus_event_measurements_unioned`,
+  `nexus_event_dimensions_unioned`: the finals recipe over the source unions,
+  with `nexus_incremental_require_ingested_at()` enforcing at compile time
+  that every unioned client model exposes `_ingested_at` (a union sharing one
+  watermark silently drops rows from a source without it). The dimension/
+  measurement pivot finals stay full rebuilds (small, and rebuilding avoids
+  NULL-backfill divergence when new `is_*` columns appear).
+- `nexus_entity_participants`: two legs (macros in
+  `incremental_finalize_participants.sql`). The APPEND leg processes batch
+  identifier rows against the current resolved mapping;
+  `entity_participant_id` is stable at birth. The REPOINT leg consumes
+  `nexus_resolution_log` `repointed` rows past the table's own
+  `_resolution_log_watermark` cursor and updates `entity_id` in place —
+  joining log rows to the CURRENT resolved tables makes it self-healing
+  across batches (an unconsumed A→B followed by B→C resolves A directly to
+  C). Accepted divergence: post-merge, a (event, entity, role) grain can
+  briefly hold two rows under distinct ids; parity checks compare on the
+  DISTINCT grain (`it_participants_mapping_parity`).
+
+## 8. Future work
 
 - **Quarantine-on-entry noise filtering**: an incrementally-maintained
   per-identifier connection-count aggregate; identifiers crossing thresholds

--- a/integration_tests/run.py
+++ b/integration_tests/run.py
@@ -62,6 +62,7 @@ SCENARIO_DB_DIR = IT_DIR / "target" / "scenarios"
 RUN_SELECT = [
     "--select",
     "+nexus_resolution_log",
+    "+nexus_entity_participants",
     "+it_shadow_resolved_person",
     "+it_shadow_resolved_group",
 ]

--- a/integration_tests/tests/it_participants_mapping_parity.sql
+++ b/integration_tests/tests/it_participants_mapping_parity.sql
@@ -1,0 +1,40 @@
+{{ config(tags=["it_invariant"]) }}
+
+-- Internal consistency on the DISTINCT grain: participants must equal
+-- exactly what the CURRENT resolved mapping implies from the identifier
+-- rows — no missing rows (append leg lost something) and no extras
+-- (repoint leg pointed somewhere the mapping doesn't). The distinct grain
+-- deliberately tolerates the documented post-merge duplicate-id divergence.
+with
+{% for t in ['person', 'group'] %}
+expected_{{ t }} as (
+    select distinct ei.event_id, m.{{ t }}_id as entity_id, ei.role
+    from {{ ref('nexus_entity_identifiers') }} ei
+    join {{ ref('nexus_resolved_' ~ t ~ '_identifiers') }} m
+      on ei.identifier_type = m.identifier_type
+     and ei.identifier_value = m.identifier_value
+    where ei.entity_type = '{{ t }}'
+),
+actual_{{ t }} as (
+    select distinct event_id, entity_id, role
+    from {{ ref('nexus_entity_participants') }}
+    where entity_type = '{{ t }}'
+){{ "," if not loop.last }}
+{% endfor %}
+
+{% for t in ['person', 'group'] %}
+select '{{ t }}' as entity_type, 'missing' as problem, e.event_id, e.entity_id, e.role
+from expected_{{ t }} e
+left join actual_{{ t }} a
+  on e.event_id = a.event_id and e.entity_id = a.entity_id and e.role is not distinct from a.role
+where a.event_id is null
+union all
+select '{{ t }}' as entity_type, 'extra' as problem, a.event_id, a.entity_id, a.role
+from actual_{{ t }} a
+left join expected_{{ t }} e
+  on e.event_id = a.event_id and e.entity_id = a.entity_id and e.role is not distinct from a.role
+where e.event_id is null
+{% if not loop.last %}
+union all
+{% endif %}
+{% endfor %}

--- a/integration_tests/tests/it_participants_no_live_losers.sql
+++ b/integration_tests/tests/it_participants_no_live_losers.sql
@@ -1,0 +1,17 @@
+{{ config(tags=["it_invariant"]) }}
+
+-- Participants may never point at an entity id that lost a merge: the
+-- repoint leg must move rows off repointed previous_entity_ids in the same
+-- run that logged the repoint.
+select
+    p.entity_participant_id,
+    p.entity_type,
+    p.entity_id as dead_entity_id_still_referenced
+from {{ ref('nexus_entity_participants') }} p
+join (
+    select distinct entity_type, previous_entity_id
+    from {{ ref('nexus_resolution_log') }}
+    where resolution_reason = 'repointed'
+) losers
+  on p.entity_type = losers.entity_type
+ and p.entity_id = losers.previous_entity_id

--- a/macros/config/nexus_bq_informational_constraints.sql
+++ b/macros/config/nexus_bq_informational_constraints.sql
@@ -47,6 +47,13 @@
   {%- set statements = [] -%}
 
   {%- if primary_key -%}
+    {# PRIMARY KEY has no IF NOT EXISTS in BigQuery (unlike named FK
+       constraints), and on incremental models the table persists across
+       runs — a bare ADD collides on run 2. DROP IF EXISTS + ADD is the
+       idempotent pair. #}
+    {%- do statements.append(
+      'ALTER TABLE {{ this }} DROP PRIMARY KEY IF EXISTS'
+    ) -%}
     {%- do statements.append(
       'ALTER TABLE {{ this }} ADD PRIMARY KEY (' ~ primary_key ~ ') NOT ENFORCED'
     ) -%}

--- a/macros/config/nexus_incremental_touched_groups.sql
+++ b/macros/config/nexus_incremental_touched_groups.sql
@@ -1,0 +1,70 @@
+{#
+  Touched-group incrementality for ROLLUP models (GROUP BY collapses many
+  child rows into one group row), used by the gmail thread / cross-account
+  tables. The append recipe is wrong for rollups: a new child must recompute
+  its whole group, and the rollup's own _ingested_at is MIN/MAX of the group
+  (frozen for MIN), so it cannot be the cursor either.
+
+  Pattern (see gmail_threads_by_account for the reference conversion):
+    1. Every rollup emits `_watermark_ingested_at = MAX(child _ingested_at)`
+       per group — the reliable cursor.
+    2. On incremental runs, `nexus_incremental_touched_groups()` renders the
+       distinct group keys among upstream rows past that cursor.
+    3. The model inner-joins full upstream history to the touched keys and
+       runs its UNCHANGED aggregation over just those groups.
+    4. dbt merges on the OUTPUT-grain unique_key. There is no delete leg:
+       children are append-only, so a group's output can gain rows but never
+       lose them.
+
+  Consumers of a rollup must use the rollup's _watermark_ingested_at as
+  their batch clock (the "rollup-child clock" rule) — its _ingested_at may
+  be a frozen MIN.
+#}
+
+{% macro nexus_incremental_touched_groups(upstream_relation, group_keys, upstream_column='_ingested_at', watermark_column='_watermark_ingested_at') %}
+select distinct {{ group_keys | join(', ') }}
+from {{ upstream_relation }}
+where {{ upstream_column }} > {{ nexus.nexus_incremental_watermark_literal(watermark_column) }}
+{% endmacro %}
+
+
+{#
+  Null-safe equi-join predicate over the group keys. IS NOT DISTINCT FROM is
+  the one spelling BigQuery, DuckDB and Snowflake all accept; a plain `=`
+  silently drops NULL-keyed groups (e.g. a NULL _stream_id) and tuple-IN
+  subqueries are not portable across the three adapters.
+#}
+{% macro nexus_incremental_touched_join(left_alias, right_alias, group_keys) %}
+{%- for k in group_keys %}
+    {{ 'on' if loop.first else 'and' }} {{ left_alias }}.{{ k }} is not distinct from {{ right_alias }}.{{ k }}
+{%- endfor %}
+{% endmacro %}
+
+
+{#
+  Compile-time contract for shared-watermark unions (nexus_events, the
+  event measurement/dimension unions): one shared watermark across a union
+  means a source model missing _ingested_at loses rows SILENTLY. When the
+  incremental flag is on, fail loudly naming the offenders instead. Only
+  BUILT relations count (a relation with zero columns hasn't been created
+  yet — first runs stay quiet).
+#}
+{% macro nexus_incremental_require_ingested_at(relations, what) %}
+  {%- if execute and nexus.nexus_incremental_enabled() -%}
+    {%- set missing = [] -%}
+    {%- for rel in relations -%}
+      {%- set cols = adapter.get_columns_in_relation(rel) | map(attribute='name') | map('lower') | list -%}
+      {%- if cols | length > 0 and '_ingested_at' not in cols -%}
+        {%- do missing.append(rel | string) -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- if missing | length > 0 -%}
+      {{ exceptions.raise_compiler_error(
+          "nexus incremental: every model feeding " ~ what ~ " must expose a stable "
+          ~ "_ingested_at (real ingestion time — never occurred_at, never now()). "
+          ~ "Missing from: " ~ missing | join(", ")
+          ~ ". Fix the source model, disable the source, or turn off "
+          ~ "nexus.incremental.enabled. See docs/incremental-identity-resolution.md.") }}
+    {%- endif -%}
+  {%- endif -%}
+{% endmacro %}

--- a/macros/event-log/process_event_dimensions.sql
+++ b/macros/event-log/process_event_dimensions.sql
@@ -23,6 +23,7 @@
     {% endif %}
 
     {% if relations_to_union %}
+        {{ nexus.nexus_incremental_require_ingested_at(relations_to_union, 'nexus_event_dimensions') }}
         with unioned as (
             {{ dbt_utils.union_relations(
                 relations=relations_to_union
@@ -36,7 +37,8 @@
                 lower(dimension_name) as dimension_name,
                 dimension_value,
                 occurred_at,
-                lower(source) as source
+                lower(source) as source,
+                _ingested_at
             from unioned
         )
 
@@ -46,8 +48,13 @@
             dimension_name,
             dimension_value,
             occurred_at,
-            source
+            source,
+            _ingested_at
         from standardized
+        {% if is_incremental() %}
+        where _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+        qualify row_number() over (partition by event_dimension_id order by _ingested_at desc) = 1
+        {% endif %}
     {% else %}
         {# Return empty result if no relations found #}
         {# FROM (SELECT 1) provides a row source — BigQuery requires FROM for WHERE #}
@@ -57,7 +64,8 @@
             cast(null as string) as dimension_name,
             cast(null as string) as dimension_value,
             cast(null as timestamp) as occurred_at,
-            cast(null as string) as source
+            cast(null as string) as source,
+            cast(null as timestamp) as _ingested_at
         from (select 1)
         where 1=0
     {% endif %}

--- a/macros/event-log/process_event_measurements.sql
+++ b/macros/event-log/process_event_measurements.sql
@@ -23,6 +23,7 @@
     {% endif %}
 
     {% if relations_to_union %}
+        {{ nexus.nexus_incremental_require_ingested_at(relations_to_union, 'nexus_event_measurements') }}
         with unioned as (
             {{ dbt_utils.union_relations(
                 relations=relations_to_union
@@ -38,7 +39,8 @@
                 value,
                 lower(value_unit) as value_unit,
                 occurred_at,
-                lower(source) as source
+                lower(source) as source,
+                _ingested_at
             from unioned
         )
 
@@ -49,8 +51,13 @@
             value,
             value_unit,
             occurred_at,
-            source
+            source,
+            _ingested_at
         from standardized
+        {% if is_incremental() %}
+        where _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+        qualify row_number() over (partition by event_measurement_id order by _ingested_at desc) = 1
+        {% endif %}
     {% else %}
         {# Return empty result if no relations found #}
         {# FROM (SELECT 1) provides a row source — BigQuery requires FROM for WHERE #}
@@ -61,7 +68,8 @@
             cast(null as {{ dbt.type_float() }}) as value,
             cast(null as string) as value_unit,
             cast(null as timestamp) as occurred_at,
-            cast(null as string) as source
+            cast(null as string) as source,
+            cast(null as timestamp) as _ingested_at
         from (select 1)
         where 1=0
     {% endif %}

--- a/macros/final-tables/incremental_finalize_participants.sql
+++ b/macros/final-tables/incremental_finalize_participants.sql
@@ -1,0 +1,148 @@
+{#
+  Incremental legs for nexus_entity_participants (used when
+  nexus.incremental.enabled; the full-resolution path keeps using
+  finalize_participants / finalize_non_er_participants unchanged).
+
+  Semantics mirror stable entity ids: entity_participant_id is minted at
+  birth from (event_id, entity_id, role) and NEVER rewritten — merges update
+  entity_id in place via the repoint leg. Accepted divergence vs a full
+  rebuild: after a merge, the same (event_id, entity_type, entity_id, role)
+  grain can carry two rows (the loser's repointed row plus the survivor's
+  own). Ids stay unique; parity checks compare on the DISTINCT grain.
+#}
+
+{# Append leg (ER types): new-event participant rows, watermark on the
+   entity-identifiers ingestion clock. #}
+{% macro incremental_finalize_participants(entity_type) %}
+with resolved_identifiers as (
+  select * from {{ ref('nexus_resolved_' ~ entity_type ~ '_identifiers') }}
+),
+entity_identifiers as (
+  select * from {{ ref('nexus_entity_identifiers') }}
+  where entity_type = '{{ entity_type }}'
+  {% if is_incremental() %}
+    and _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+  {% endif %}
+),
+joined as (
+  select
+    ri.{{ entity_type }}_id,
+    ei.event_id,
+    ei.role,
+    ei.occurred_at,
+    ei._ingested_at
+  from entity_identifiers ei
+  inner join resolved_identifiers ri
+    on ei.identifier_value = ri.identifier_value
+    and ei.identifier_type = ri.identifier_type
+),
+grouped as (
+  select
+    {{ nexus.create_nexus_id('entity_participant', ['event_id', entity_type ~ '_id', 'role']) }} as entity_participant_id,
+    '{{ entity_type }}' as entity_type,
+    event_id,
+    {{ entity_type }}_id as entity_id,
+    role,
+    occurred_at,
+    max(_ingested_at) as _ingested_at
+  from joined
+  group by event_id, {{ entity_type }}_id, role, occurred_at
+)
+select g.*
+from grouped g
+{% if is_incremental() %}
+{# Re-sync-after-merge guard: a re-offered identifier row resolves to the
+   post-merge survivor, minting a NEW id for a grain that may already exist
+   under the pre-merge id. Skip those; same-id rows still merge through. #}
+left join {{ this }} t
+  on t.event_id = g.event_id
+  and t.entity_type = g.entity_type
+  and t.entity_id = g.entity_id
+  and t.role is not distinct from g.role
+  and t.entity_participant_id != g.entity_participant_id
+where t.entity_participant_id is null
+{% endif %}
+{% endmacro %}
+
+
+{# Append leg (non-ER types): registration-model join, same clock. #}
+{% macro incremental_finalize_non_er_participants(entity_type) %}
+{% set entity_config = nexus.get_entity_type_config() %}
+{% set type_config = entity_config[entity_type] %}
+{% set reg_model = type_config.get('registration_model') %}
+
+{% if reg_model %}
+with entity_identifiers as (
+  select * from {{ ref('nexus_entity_identifiers') }}
+  where entity_type = '{{ entity_type }}'
+  {% if is_incremental() %}
+    and _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+  {% endif %}
+),
+registered_entities as (
+  select entity_id, source_id
+  from {{ ref(reg_model) }}
+),
+joined as (
+  select
+    reg.entity_id,
+    ei.event_id,
+    ei.role,
+    ei.occurred_at,
+    ei._ingested_at
+  from entity_identifiers ei
+  inner join registered_entities reg
+    on ei.identifier_value = reg.source_id
+)
+select
+  {{ nexus.create_nexus_id('entity_participant', ['event_id', 'entity_id', 'role']) }} as entity_participant_id,
+  '{{ entity_type }}' as entity_type,
+  event_id,
+  entity_id,
+  role,
+  occurred_at,
+  max(_ingested_at) as _ingested_at
+from joined
+group by event_id, entity_id, role, occurred_at
+{% else %}
+select
+  cast(null as {{ dbt.type_string() }}) as entity_participant_id,
+  cast(null as {{ dbt.type_string() }}) as entity_type,
+  cast(null as {{ dbt.type_string() }}) as event_id,
+  cast(null as {{ dbt.type_string() }}) as entity_id,
+  cast(null as {{ dbt.type_string() }}) as role,
+  cast(null as {{ dbt.type_timestamp() }}) as occurred_at,
+  cast(null as {{ dbt.type_timestamp() }}) as _ingested_at
+from (select 1) _ where 1=0
+{% endif %}
+{% endmacro %}
+
+
+{# Repoint leg (ER types, incremental runs only): rows sitting at a merged-
+   away entity move to the survivor. Joining log rows to the CURRENT resolved
+   table (not to rl.entity_id) makes the mapping self-healing across batches:
+   an unconsumed A→B followed by B→C resolves A directly to C — no
+   transitive-closure pass needed. The id is untouched. #}
+{% macro incremental_participants_repoint(entity_type) %}
+select
+  t.entity_participant_id,
+  t.entity_type,
+  t.event_id,
+  m.new_entity_id as entity_id,
+  t.role,
+  t.occurred_at,
+  t._ingested_at
+from {{ this }} t
+inner join (
+  select distinct rl.previous_entity_id, cur.{{ entity_type }}_id as new_entity_id
+  from {{ ref('nexus_resolution_log') }} rl
+  inner join {{ ref('nexus_resolved_' ~ entity_type ~ '_identifiers') }} cur
+    on cur.identifier_type = rl.identifier_type
+    and cur.identifier_value = rl.identifier_value
+  where rl.entity_type = '{{ entity_type }}'
+    and rl.resolution_reason = 'repointed'
+    and rl.resolved_at_watermark > {{ nexus.nexus_incremental_watermark_literal('_resolution_log_watermark') }}
+) m
+  on t.entity_id = m.previous_entity_id
+where t.entity_type = '{{ entity_type }}'
+{% endmacro %}

--- a/models/core/nexus_entity_participants.sql
+++ b/models/core/nexus_entity_participants.sql
@@ -1,7 +1,9 @@
 {{ config(
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
     partition_by=nexus.nexus_bq_partition_by('occurred_at', granularity='month'),
     cluster_by=nexus.nexus_cluster_by(['entity_type', 'event_id']),
+    unique_key='entity_participant_id',
+    on_schema_change='append_new_columns',
     post_hook=nexus.nexus_bq_informational_constraints(
         primary_key='entity_participant_id',
         foreign_keys=[
@@ -10,6 +12,8 @@
     ),
     tags=['identity-resolution', 'participants', 'realtime']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', '_resolution_log_watermark']) }}
 
 {# Monthly (not daily) partitioning on occurred_at: participant data
    inherits timestamps from every event source the package unions in
@@ -33,6 +37,82 @@
 {% set non_er_types = nexus.get_non_er_entity_types() %}
 {% set entity_config = nexus.get_entity_type_config() %}
 
+{% if nexus.nexus_incremental_enabled() %}
+{# Incremental mode: append legs (new-event rows, watermark on the
+   entity-identifiers clock) plus, on incremental runs, a repoint leg per ER
+   type driven by nexus_resolution_log 'repointed' rows past this table's
+   own _resolution_log_watermark cursor. entity_participant_id is stable at
+   birth — merges update entity_id in place. See
+   incremental_finalize_participants.sql for the leg SQL and the accepted
+   post-merge duplicate-grain divergence. #}
+
+-- depends_on: {{ ref('nexus_resolution_log') }}
+{# ^ the repoint CTEs live inside is_incremental() and the log ref would be
+   invisible to parse-time extraction; the log must build first (it also
+   supplies the cursor stamp below). #}
+
+with
+{% for entity_type in er_types %}
+{{ entity_type }}_participants as (
+  {{ nexus.incremental_finalize_participants(entity_type) }}
+),
+{% endfor %}
+{% for entity_type in non_er_types %}
+{{ entity_type }}_participants as (
+  {{ nexus.incremental_finalize_non_er_participants(entity_type) }}
+),
+{% endfor %}
+{% if is_incremental() %}
+{% for entity_type in er_types %}
+{{ entity_type }}_repointed as (
+  {{ nexus.incremental_participants_repoint(entity_type) }}
+),
+{% endfor %}
+{% endif %}
+
+unioned as (
+{% set all_types = er_types + non_er_types %}
+{% for entity_type in all_types %}
+  select * from {{ entity_type }}_participants
+  {{ "union all" if not loop.last }}
+{% endfor %}
+{% if is_incremental() %}
+{% for entity_type in er_types %}
+  union all
+  select * from {{ entity_type }}_repointed
+{% endfor %}
+{% endif %}
+)
+
+select
+  entity_participant_id,
+  entity_type,
+  event_id,
+  entity_id,
+  role,
+  occurred_at,
+  _ingested_at,
+  {# Cursor bookkeeping: every emitted row is stamped with the CURRENT log
+     head; the next run's repoint window is (max(stored), new head]. A
+     zero-row run leaves the cursor put — replaying a window is a no-op
+     because replayed rows no longer sit at previous_entity_id. The
+     load_relation guard covers `dbt compile` against a database where the
+     log doesn't exist yet; at run time depends_on guarantees it does. #}
+  {%- if execute and load_relation(ref('nexus_resolution_log')) is not none %}
+  {{ nexus.nexus_incremental_watermark_literal('resolved_at_watermark', relation=ref('nexus_resolution_log')) }} as _resolution_log_watermark
+  {%- else %}
+  cast('1970-01-01' as timestamp) as _resolution_log_watermark
+  {%- endif %}
+from unioned
+{% if is_incremental() %}
+{# Append and repoint can emit the same id in one batch (they agree on the
+   destination entity) — keep one deterministically. #}
+qualify row_number() over (partition by entity_participant_id order by entity_id) = 1
+{% endif %}
+
+{% else %}
+{# Full-resolution mode (flag off): unchanged original path. #}
+
 with
 {% for entity_type in er_types %}
 {{ entity_type }}_participants as (
@@ -55,3 +135,5 @@ union all
 select * from {{ entity_type }}_participants
 {% endif %}
 {% endfor %}
+
+{% endif %}

--- a/models/core/nexus_events.sql
+++ b/models/core/nexus_events.sql
@@ -1,9 +1,18 @@
 {{ config(
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
     partition_by=nexus.nexus_bq_partition_by('occurred_at', granularity='month'),
     cluster_by=nexus.nexus_cluster_by(['event_name', 'source']),
+    unique_key='event_id',
+    on_schema_change='append_new_columns',
     post_hook=nexus.nexus_bq_informational_constraints(primary_key='event_id'),
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'event_id']) }}
+
+{# Partitioning stays on occurred_at (downstream reads prune on event time).
+   The incremental watermark predicate prunes the UPSTREAM source finals,
+   which are partitioned on _ingested_at — this table's own scan cost is the
+   merge target only. #}
 
 {# Monthly (not daily) partitioning on occurred_at: event history in
    real tenants commonly spans more than the 4000-partition BigQuery
@@ -111,6 +120,8 @@
     {% endif %}
 {% endfor %}
 
+{{ nexus.nexus_incremental_require_ingested_at(relations_to_union, 'nexus_events') }}
+
 WITH unioned AS (
     {{ dbt_utils.union_relations(
         relations=relations_to_union,
@@ -140,11 +151,7 @@ SELECT
     {{ processed_columns | join(',\n    ') }},
     current_timestamp() as _processed_at
 FROM unioned
-{# BigQuery rejects `ORDER BY` in a CTAS that uses `partition_by`.
-   The ORDER BY at write time was never load-bearing for downstream
-   consumers — BigQuery and Snowflake both re-sort at read time when
-   needed — so we drop it whenever partitioning is on. Without
-   partitioning, preserve the historical ordering hint. #}
-{% if not (nexus.nexus_warehouse_optimization_enabled() and target.type == 'bigquery') %}
-ORDER BY occurred_at DESC
+{% if is_incremental() %}
+WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+QUALIFY row_number() OVER (PARTITION BY event_id ORDER BY _ingested_at DESC) = 1
 {% endif %}

--- a/models/intermediate/dimensions/nexus_event_dimensions_unioned.sql
+++ b/models/intermediate/dimensions/nexus_event_dimensions_unioned.sql
@@ -1,8 +1,15 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_dimension_id']),
+    unique_key='event_dimension_id',
+    on_schema_change='append_new_columns'
+) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'event_dimension_id']) }}
 
 -- Nexus Event Dimensions
 -- Unions all source-level event dimension models into a single table.
 -- Each row represents a single categorical property extracted from an event.
 
 {{ nexus.process_event_dimensions() }}
-order by occurred_at desc

--- a/models/intermediate/measurements/nexus_event_measurements_unioned.sql
+++ b/models/intermediate/measurements/nexus_event_measurements_unioned.sql
@@ -1,8 +1,15 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_measurement_id']),
+    unique_key='event_measurement_id',
+    on_schema_change='append_new_columns'
+) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'event_measurement_id']) }}
 
 -- Nexus Event Measurements
 -- Unions all source-level event measurement models into a single table.
 -- Each row represents a single quantitative observation extracted from an event.
 
 {{ nexus.process_event_measurements() }}
-order by occurred_at desc

--- a/models/sources/gmail/intermediate/gmail_message_events.sql
+++ b/models/sources/gmail/intermediate/gmail_message_events.sql
@@ -1,10 +1,23 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_id']),
+    unique_key='event_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'intermediate', 'events']
 ) }}
 
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'event_id']) }}
+
 {% set bodies_enabled = var('nexus', {}).get('sources', {}).get('gmail', {}).get('bodies', false) %}
+{% if bodies_enabled and nexus.nexus_incremental_enabled() %}
+{# A body fetched AFTER its message was absorbed never re-offers the row
+   (bodies ride fetched_at, not _ingested_at), so the joined body columns
+   would freeze as NULL forever. No client runs this combination; make it
+   impossible to hit silently. #}
+{{ exceptions.raise_compiler_error("gmail bodies + nexus.incremental.enabled is not supported yet: late-fetched bodies never re-offer their message row. Disable one of the two.") }}
+{% endif %}
 
 -- Extract message events from normalized gmail messages
 SELECT
@@ -59,5 +72,8 @@ FROM {{ ref('gmail_messages') }} m
 {% if bodies_enabled %}
 LEFT JOIN {{ ref('gmail_message_bodies') }} b
     ON m.message_id = b.message_id_header
+{% endif %}
+{% if is_incremental() %}
+WHERE m._ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
 {% endif %}
 

--- a/models/sources/gmail/intermediate/gmail_message_group_identifiers.sql
+++ b/models/sources/gmail/intermediate/gmail_message_group_identifiers.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_identifier_id']),
+    unique_key='entity_identifier_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'intermediate', 'group_identifiers']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_identifier_id']) }}
 
 -- Extract group (domain) identifiers from gmail message participants
 WITH participants AS (
     SELECT * FROM {{ ref('gmail_message_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 -- Filter out generic domains
@@ -95,4 +104,3 @@ SELECT
     role
 FROM deduplicated_identifiers
 WHERE rn = 1
-ORDER BY occurred_at DESC

--- a/models/sources/gmail/intermediate/gmail_message_group_traits.sql
+++ b/models/sources/gmail/intermediate/gmail_message_group_traits.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_trait_id']),
+    unique_key='entity_trait_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'intermediate', 'group_traits']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_trait_id']) }}
 
 -- Extract group (domain) traits from gmail message participants
 WITH participants AS (
     SELECT * FROM {{ ref('gmail_message_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 -- Filter out generic domains
@@ -64,4 +73,3 @@ SELECT
     _ingested_at
 FROM deduplicated_traits
 WHERE rn = 1
-ORDER BY occurred_at DESC

--- a/models/sources/gmail/intermediate/gmail_message_person_identifiers.sql
+++ b/models/sources/gmail/intermediate/gmail_message_person_identifiers.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_identifier_id']),
+    unique_key='entity_identifier_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'intermediate', 'person_identifiers']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_identifier_id']) }}
 
 -- Extract person identifiers from gmail message participants
 WITH participants AS (
     SELECT * FROM {{ ref('gmail_message_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 participants_with_event_id AS (
@@ -61,4 +70,3 @@ SELECT
     role
 FROM deduplicated_identifiers
 WHERE rn = 1
-ORDER BY occurred_at DESC

--- a/models/sources/gmail/intermediate/gmail_message_person_traits.sql
+++ b/models/sources/gmail/intermediate/gmail_message_person_traits.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_trait_id']),
+    unique_key='entity_trait_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'intermediate', 'person_traits']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_trait_id']) }}
 
 -- Extract person traits from gmail message participants
 WITH participants AS (
     SELECT * FROM {{ ref('gmail_message_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 participants_with_event_id AS (
@@ -80,4 +89,3 @@ SELECT
     _ingested_at
 FROM deduplicated_traits
 WHERE rn = 1
-ORDER BY occurred_at DESC

--- a/models/sources/gmail/intermediate/gmail_message_relationship_declarations.sql
+++ b/models/sources/gmail/intermediate/gmail_message_relationship_declarations.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['relationship_declaration_id']),
+    unique_key='relationship_declaration_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'intermediate', 'relationship_declarations']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'relationship_declaration_id']) }}
 
 -- Extract person→group relationships from gmail message participants
 WITH participants AS (
     SELECT * FROM {{ ref('gmail_message_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 -- Extract participants with valid email and domain (filter generic domains)
@@ -98,4 +107,3 @@ SELECT
     _ingested_at
 FROM deduplicated_relationships
 WHERE rn = 1
-ORDER BY occurred_at DESC

--- a/models/sources/gmail/intermediate/gmail_thread_events.sql
+++ b/models/sources/gmail/intermediate/gmail_thread_events.sql
@@ -1,10 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_id']),
+    unique_key='event_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'intermediate', 'events']
 ) }}
 
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'event_id']) }}
+
 -- Extract thread started events from normalized gmail threads
+--
+-- Rollup-child clock rule: gmail_threads' _ingested_at is a frozen MIN, so
+-- events are stamped from its _watermark_ingested_at — otherwise gmail_events
+-- would never re-merge a thread's row when the thread gains messages (its
+-- last_message_sent_at, labels etc. would freeze at first sight).
 SELECT
     {{ nexus.create_nexus_id('event', ['thread_id', "'thread started'"]) }} as event_id,
     first_message_sent_at as occurred_at,
@@ -14,7 +25,7 @@ SELECT
     0 as significance,
     'gmail' as source,
     'gmail_thread_events' as source_table,
-    _ingested_at,
+    _watermark_ingested_at as _ingested_at,
     
     -- Additional fields
     thread_id,
@@ -36,4 +47,7 @@ SELECT
     all_label_ids
     
 FROM {{ ref('gmail_threads') }}
+{% if is_incremental() %}
+WHERE _watermark_ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+{% endif %}
 

--- a/models/sources/gmail/intermediate/gmail_thread_group_identifiers.sql
+++ b/models/sources/gmail/intermediate/gmail_thread_group_identifiers.sql
@@ -1,12 +1,22 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_identifier_id']),
+    unique_key='entity_identifier_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'intermediate', 'group_identifiers']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_identifier_id']) }}
 
 -- Extract group (domain) identifiers from gmail thread participants
 WITH participants AS (
     SELECT * FROM {{ ref('gmail_thread_participants') }}
+    {% if is_incremental() %}
+    -- rollup-child clock: the upstream's _ingested_at is a frozen MIN
+    WHERE _watermark_ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 -- Filter out generic domains
@@ -15,7 +25,7 @@ domains_filtered AS (
         {{ nexus.create_nexus_id('event', ['thread_id', "'thread started'"]) }} as event_id,
         thread_id,
         first_participated_at,
-        _ingested_at,
+        _watermark_ingested_at as _ingested_at,
         domain,
         roles
     FROM participants
@@ -33,7 +43,7 @@ domains_with_roles AS (
         domain,
         role
     FROM domains_filtered,
-    UNNEST(roles) as role
+    UNNEST(roles) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}
 ),
 
 -- Create domain identifiers
@@ -109,5 +119,3 @@ SELECT
     role
 FROM deduplicated_identifiers
 WHERE rn = 1
-ORDER BY occurred_at DESC
-

--- a/models/sources/gmail/intermediate/gmail_thread_person_identifiers.sql
+++ b/models/sources/gmail/intermediate/gmail_thread_person_identifiers.sql
@@ -1,12 +1,22 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_identifier_id']),
+    unique_key='entity_identifier_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'intermediate', 'person_identifiers']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_identifier_id']) }}
 
 -- Extract person identifiers from gmail thread participants
 WITH participants AS (
     SELECT * FROM {{ ref('gmail_thread_participants') }}
+    {% if is_incremental() %}
+    -- rollup-child clock: the upstream's _ingested_at is a frozen MIN
+    WHERE _watermark_ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 participants_with_event_id AS (
@@ -15,7 +25,7 @@ participants_with_event_id AS (
         thread_id,
         email,
         first_participated_at,
-        _ingested_at,
+        _watermark_ingested_at as _ingested_at,
         roles
     FROM participants
     WHERE email IS NOT NULL
@@ -31,7 +41,7 @@ participants_with_roles AS (
         _ingested_at,
         role
     FROM participants_with_event_id,
-    UNNEST(roles) as role
+    UNNEST(roles) as {% if target.type == 'duckdb' %}t(role){% else %}role{% endif %}
 ),
 
 identifiers AS (
@@ -74,5 +84,3 @@ SELECT
     role
 FROM deduplicated_identifiers
 WHERE rn = 1
-ORDER BY occurred_at DESC
-

--- a/models/sources/gmail/normalized/gmail_message_participants.sql
+++ b/models/sources/gmail/normalized/gmail_message_participants.sql
@@ -1,11 +1,25 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['message_id']),
+    unique_key=['message_id', 'email', 'role'],
+    on_schema_change='append_new_columns',
     tags=['gmail', 'normalized']
 ) }}
 
+{{ nexus.nexus_incremental_upgrade_guard(['_watermark_ingested_at', 'message_id']) }}
+
+{% if is_incremental() %}
+{% set wm = nexus.nexus_incremental_watermark_literal('_watermark_ingested_at') %}
+{% endif %}
+
 -- Cross-account normalized participants: Group per-account participants by message_id_header
-WITH per_account_participants AS (
+--
+-- Touched-group rollup: touched headers = headers of batch participants
+-- UNION headers of batch messages (a re-synced message can remap its
+-- header), recomputed from full history and merged on the output grain.
+WITH per_account_participants_all AS (
     SELECT
         p.participant_raw,
         p.name,
@@ -14,12 +28,28 @@ WITH per_account_participants AS (
         p.role,
         p.sent_at,
         p._ingested_at,
+        m._ingested_at as _message_ingested_at,
         m.message_id_header as message_id
     FROM {{ ref('gmail_message_participants_by_account') }} p
     INNER JOIN {{ ref('gmail_messages_by_account') }} m 
         ON p.gmail_message_id = m.gmail_message_id 
         AND p._account = m._account
     WHERE m.message_id_header IS NOT NULL
+),
+
+{% if is_incremental() %}
+touched_headers AS (
+    SELECT DISTINCT message_id
+    FROM per_account_participants_all
+    WHERE _ingested_at > {{ wm }} OR _message_ingested_at > {{ wm }}
+),
+{% endif %}
+
+per_account_participants AS (
+    SELECT pa.* FROM per_account_participants_all pa
+    {% if is_incremental() %}
+    INNER JOIN touched_headers th ON pa.message_id = th.message_id
+    {% endif %}
 ),
 
 -- Cross-account deduplication: group by message_id_header, email, and role
@@ -33,7 +63,8 @@ grouped_participants AS (
         {% if target.type == 'bigquery' %}ARRAY_AGG(name ORDER BY sent_at DESC, _ingested_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(name ORDER BY sent_at DESC, _ingested_at DESC){% endif %} as name,
         {% if target.type == 'bigquery' %}ARRAY_AGG(domain ORDER BY sent_at DESC, _ingested_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(domain ORDER BY sent_at DESC, _ingested_at DESC){% endif %} as domain,
         MAX(sent_at) as sent_at,
-        MAX(_ingested_at) as _ingested_at
+        MAX(_ingested_at) as _ingested_at,
+        GREATEST(MAX(_ingested_at), MAX(_message_ingested_at)) as _watermark_ingested_at
     FROM per_account_participants
     WHERE message_id IS NOT NULL
     GROUP BY message_id, email, role
@@ -48,7 +79,8 @@ SELECT
     domain,
     role,
     sent_at,
-    _ingested_at
+    _ingested_at,
+    _watermark_ingested_at
 FROM grouped_participants
 ORDER BY message_id, 
     CASE role 
@@ -61,4 +93,3 @@ ORDER BY message_id,
 )
 
 select * from final
-ORDER BY sent_at desc

--- a/models/sources/gmail/normalized/gmail_messages.sql
+++ b/models/sources/gmail/normalized/gmail_messages.sql
@@ -1,17 +1,56 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['message_id']),
+    unique_key='message_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'normalized']
 ) }}
 
+{{ nexus.nexus_incremental_upgrade_guard(['_watermark_ingested_at', 'message_id']) }}
+
+{% if is_incremental() %}
+{% set wm = nexus.nexus_incremental_watermark_literal('_watermark_ingested_at') %}
+{% endif %}
+
 -- Cross-account normalized messages: Group per-account messages by message_id_header
 -- Join with per-account threads to get thread_id from first_message_id_header
-WITH per_account_messages AS (
+--
+-- Touched-group rollup, WIDENED touched-set: thread_id routes through the
+-- per-account thread's first_message_id_header, so when a thread gains a
+-- message, every message of that thread must be recomputed — touched
+-- headers = batch messages UNION all messages of touched threads. A
+-- batch-only touched-set would leave the thread's other messages stale.
+WITH per_account_messages_all AS (
     SELECT * FROM {{ ref('gmail_messages_by_account') }}
 ),
 
 per_account_threads AS (
     SELECT * FROM {{ ref('gmail_threads_by_account') }}
+),
+
+{% if is_incremental() %}
+touched_headers AS (
+    SELECT DISTINCT message_id_header
+    FROM per_account_messages_all
+    WHERE _ingested_at > {{ wm }}
+      AND message_id_header IS NOT NULL
+    UNION DISTINCT
+    SELECT DISTINCT m.message_id_header
+    FROM per_account_messages_all m
+    INNER JOIN per_account_threads t
+    {{ nexus.nexus_incremental_touched_join('m', 't', ['gmail_thread_id', '_account', '_stream_id']) }}
+    WHERE t._watermark_ingested_at > {{ wm }}
+      AND m.message_id_header IS NOT NULL
+),
+{% endif %}
+
+per_account_messages AS (
+    SELECT m.* FROM per_account_messages_all m
+    {% if is_incremental() %}
+    INNER JOIN touched_headers th ON m.message_id_header = th.message_id_header
+    {% endif %}
 ),
 
 -- Cross-account deduplication: group by message_id_header, keep latest
@@ -36,6 +75,7 @@ grouped_messages AS (
         {% if target.type == 'bigquery' %}ARRAY_AGG(size_estimate ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(size_estimate ORDER BY sent_at DESC){% endif %} as size_estimate,
         'gmail' as source,
         MAX(_ingested_at) as _ingested_at,
+        MAX(_ingested_at) as _watermark_ingested_at,
         -- Get the latest gmail_thread_id and _account for joining with threads
         {% if target.type == 'bigquery' %}ARRAY_AGG(gmail_thread_id ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(gmail_thread_id ORDER BY sent_at DESC){% endif %} as last_gmail_thread_id,
         {% if target.type == 'bigquery' %}ARRAY_AGG(_account ORDER BY sent_at DESC LIMIT 1)[OFFSET(0)]{% else %}first(_account ORDER BY sent_at DESC){% endif %} as _account,
@@ -120,6 +160,7 @@ joined as (
         gm.size_estimate,
         gm.source,
         gm._ingested_at,
+        gm._watermark_ingested_at,
         gm.gmail_message_ids,
         gm.gmail_thread_ids,
         gm.label_ids,
@@ -133,4 +174,3 @@ joined as (
 )
 
 select * from joined
-ORDER BY sent_at desc

--- a/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_message_participants_by_account.sql
+++ b/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_message_participants_by_account.sql
@@ -1,8 +1,14 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['gmail_message_id']),
+    unique_key=['gmail_message_id', '_account', 'email', 'role'],
+    on_schema_change='append_new_columns',
     tags=['gmail', 'normalized', 'by_account']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'gmail_message_id']) }}
 
 -- Per-account normalized participants: Extract, parse, and normalize all participants (senders and recipients) from Gmail messages
 -- Creates one row per participant per message, with role indicating "sender", "recipient", "cced", or "bcced"
@@ -16,6 +22,9 @@ WITH source_data AS (
         _raw_record
     FROM {{ ref('gmail_messages_base_dedupped') }}
     WHERE JSON_EXTRACT_SCALAR(_raw_record, '$.id') IS NOT NULL
+    {% if is_incremental() %}
+    AND _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 -- Extract headers (message-id, from, to, cc, bcc)
@@ -257,4 +266,3 @@ ORDER BY gmail_message_id,
 )
 
 select * from final
-order by sent_at desc

--- a/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_messages_by_account.sql
+++ b/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_messages_by_account.sql
@@ -1,12 +1,25 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['gmail_message_id']),
+    unique_key=['gmail_message_id', '_account'],
+    on_schema_change='append_new_columns',
     tags=['gmail', 'normalized', 'by_account']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'gmail_message_id']) }}
 
 {% set internal_domains = var('internal_domains', []) %}
 {% set filter_internal_only_messages = var('nexus', {}).get('sources', {}).get('gmail', {}).get('filter_internal_only_messages', false) %}
 {% set should_filter_internal_only_messages = filter_internal_only_messages and (internal_domains | length > 0) %}
+{% if is_incremental() %}
+{# ONE literal shared by both batch filters below: source_data and
+   participant_domain_summary propagate the same base row's _ingested_at,
+   so a single watermark guarantees the domain summary covers exactly the
+   batch's messages. #}
+{% set wm = nexus.nexus_incremental_watermark_literal('_ingested_at') %}
+{% endif %}
 
 -- Per-account normalization: Clean messages using gmail_message_id (not cross-account)
 -- Extracts data from new STANDARD_TABLE_SCHEMA with _raw_record and headers array
@@ -21,6 +34,9 @@ WITH source_data AS (
         _sync_metadata,
         _raw_record
     FROM {{ ref('gmail_messages_base_dedupped') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ wm }}
+    {% endif %}
 ),
 
 -- Extract headers for message-level data only
@@ -92,6 +108,9 @@ participant_domain_summary AS (
         COUNT(*) as external_participant_count
         {% endif %}
     FROM {{ ref('gmail_message_participants_by_account') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ wm }}
+    {% endif %}
     GROUP BY gmail_message_id, _account
 ),
 
@@ -207,5 +226,4 @@ filtered_message AS (
 
 
 SELECT * FROM filtered_message
-ORDER BY sent_at ASC
 

--- a/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_thread_participants_by_account.sql
+++ b/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_thread_participants_by_account.sql
@@ -1,10 +1,20 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['gmail_thread_id', '_account']),
+    unique_key=['gmail_thread_id', '_account', 'email'],
+    on_schema_change='append_new_columns',
     tags=['gmail', 'normalized', 'by_account']
 ) }}
 
+{{ nexus.nexus_incremental_upgrade_guard(['_watermark_ingested_at', 'gmail_thread_id']) }}
+
 -- Per-account normalized thread participants: Aggregate participants by gmail_thread_id
+--
+-- Touched-group rollup (see nexus_incremental_touched_groups.sql). The
+-- touched-set unions BOTH upstreams' batches: a new participant row touches
+-- its thread, and a re-synced message can change thread linkage.
 WITH messages AS (
     SELECT * FROM {{ ref('gmail_messages_by_account') }}
 ),
@@ -12,6 +22,21 @@ WITH messages AS (
 participants AS (
     SELECT * FROM {{ ref('gmail_message_participants_by_account') }}
 ),
+
+{% if is_incremental() %}
+touched_threads AS (
+    SELECT DISTINCT m.gmail_thread_id, m._account
+    FROM messages m
+    INNER JOIN participants p
+        ON p.gmail_message_id = m.gmail_message_id
+        AND p._account = m._account
+    WHERE p._ingested_at > {{ nexus.nexus_incremental_watermark_literal('_watermark_ingested_at') }}
+    UNION DISTINCT
+    SELECT DISTINCT gmail_thread_id, _account
+    FROM messages
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_watermark_ingested_at') }}
+),
+{% endif %}
 
 participants_with_threads AS (
     SELECT 
@@ -29,6 +54,10 @@ participants_with_threads AS (
     INNER JOIN messages m 
         ON p.gmail_message_id = m.gmail_message_id 
         AND p._account = m._account
+    {% if is_incremental() %}
+    INNER JOIN touched_threads tt
+    {{ nexus.nexus_incremental_touched_join('m', 'tt', ['gmail_thread_id', '_account']) }}
+    {% endif %}
     WHERE m.gmail_thread_id IS NOT NULL
       AND p.email IS NOT NULL
 ),
@@ -45,6 +74,7 @@ thread_participants AS (
         MIN(sent_at) as first_participated_at,
         MAX(sent_at) as last_participated_at,
         MIN(_ingested_at) as _ingested_at,
+        MAX(_ingested_at) as _watermark_ingested_at,
     FROM participants_with_threads
     GROUP BY gmail_thread_id, _account, email, domain
 ),
@@ -70,7 +100,8 @@ SELECT
     ) as     roles,
     first_participated_at,
     last_participated_at,
-    _ingested_at
+    _ingested_at,
+    _watermark_ingested_at
 FROM thread_participants
 ORDER BY gmail_thread_id, 
     CASE 
@@ -85,4 +116,3 @@ ORDER BY gmail_thread_id,
 )
 
 select * from final
-ORDER BY last_participated_at desc

--- a/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_threads_by_account.sql
+++ b/models/sources/gmail/normalized/gmail_normalized_by_account/gmail_threads_by_account.sql
@@ -1,13 +1,38 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['gmail_thread_id', '_account']),
+    unique_key=['gmail_thread_id', '_account', '_stream_id'],
+    on_schema_change='append_new_columns',
     tags=['gmail', 'normalized', 'by_account']
 ) }}
 
+{{ nexus.nexus_incremental_upgrade_guard(['_watermark_ingested_at', 'gmail_thread_id']) }}
+
+{% set group_keys = ['gmail_thread_id', '_account', '_stream_id'] %}
+
 -- Per-account normalized threads: Aggregate messages by gmail_thread_id (per account)
 -- Uses Gmail's native thread_id for per-account threading
-WITH messages AS (
-    SELECT * FROM {{ ref('gmail_messages_by_account') }}
+--
+-- Touched-group rollup (see nexus_incremental_touched_groups.sql): children
+-- are append-only, so touched groups can only grow; recomputing them from
+-- full upstream and merging on the output grain needs no delete leg. Two
+-- scans by design: (1) batch scan for touched keys (partition-pruned via
+-- the constant watermark literal), (2) full-history scan joined to touched
+-- keys — compute and write shrink to the touched groups' children.
+WITH
+{% if is_incremental() %}
+touched_groups AS (
+    {{ nexus.nexus_incremental_touched_groups(ref('gmail_messages_by_account'), group_keys) }}
+),
+{% endif %}
+messages AS (
+    SELECT m.* FROM {{ ref('gmail_messages_by_account') }} m
+    {% if is_incremental() %}
+    INNER JOIN touched_groups tg
+    {{ nexus.nexus_incremental_touched_join('m', 'tg', group_keys) }}
+    {% endif %}
 ),
 
 thread_summary AS (
@@ -79,6 +104,7 @@ SELECT
     ts.root_gmail_message_id,
     ts.first_message_id_header,
     ts.first_ingested_at as _ingested_at,
+    ts.last_ingested_at as _watermark_ingested_at,
     ts._account,
     ts._stream_id,
     tl.label_ids
@@ -87,5 +113,4 @@ LEFT JOIN thread_labels tl
     ON ts.gmail_thread_id = tl.gmail_thread_id
     AND ts._account = tl._account
     AND ts._stream_id = tl._stream_id
-ORDER BY ts.last_message_sent_at DESC
 

--- a/models/sources/gmail/normalized/gmail_thread_participants.sql
+++ b/models/sources/gmail/normalized/gmail_thread_participants.sql
@@ -1,10 +1,25 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['thread_id']),
+    unique_key=['thread_id', 'email'],
+    on_schema_change='append_new_columns',
     tags=['gmail', 'normalized']
 ) }}
 
+{{ nexus.nexus_incremental_upgrade_guard(['_watermark_ingested_at', 'thread_id']) }}
+
+{% if is_incremental() %}
+{% set wm = nexus.nexus_incremental_watermark_literal('_watermark_ingested_at') %}
+{% endif %}
+
 -- Cross-account normalized thread participants: Group per-account participants by first_message_id_header
+--
+-- Touched-group rollup. Child clocks = both upstream rollups'
+-- _watermark_ingested_at (their _ingested_at is a frozen MIN); a touched
+-- thread re-derives ALL its participants. Same first_message_id_header
+-- re-key caveat as gmail_threads (stale old-key rows heal on full refresh).
 WITH per_account_participants AS (
     SELECT * FROM {{ ref('gmail_thread_participants_by_account') }}
 ),
@@ -12,6 +27,23 @@ WITH per_account_participants AS (
 per_account_threads AS (
     SELECT * FROM {{ ref('gmail_threads_by_account') }}
 ),
+
+{% if is_incremental() %}
+touched_thread_keys AS (
+    SELECT DISTINCT pat.first_message_id_header
+    FROM per_account_threads pat
+    INNER JOIN per_account_participants pap
+        ON pap.gmail_thread_id = pat.gmail_thread_id
+        AND pap._account = pat._account
+    WHERE pap._watermark_ingested_at > {{ wm }}
+      AND pat.first_message_id_header IS NOT NULL
+    UNION DISTINCT
+    SELECT DISTINCT first_message_id_header
+    FROM per_account_threads
+    WHERE _watermark_ingested_at > {{ wm }}
+      AND first_message_id_header IS NOT NULL
+),
+{% endif %}
 
 participants_with_thread_id AS (
     SELECT 
@@ -23,11 +55,15 @@ participants_with_thread_id AS (
         pap.roles,
         pap.first_participated_at,
         pap.last_participated_at,
-        pap._ingested_at
+        pap._ingested_at,
+        GREATEST(pap._watermark_ingested_at, pat._watermark_ingested_at) as _watermark_ingested_at
     FROM per_account_participants pap
     INNER JOIN per_account_threads pat
         ON pap.gmail_thread_id = pat.gmail_thread_id
         AND pap._account = pat._account
+    {% if is_incremental() %}
+    INNER JOIN touched_thread_keys tk ON pat.first_message_id_header = tk.first_message_id_header
+    {% endif %}
     WHERE pat.first_message_id_header IS NOT NULL
 ),
 
@@ -41,7 +77,8 @@ thread_participants AS (
         {% if target.type == 'bigquery' %}ARRAY_CONCAT_AGG(roles){% else %}flatten(array_agg(roles)){% endif %} as roles_raw,
         MIN(first_participated_at) as first_participated_at,
         MAX(last_participated_at) as last_participated_at,
-        MIN(_ingested_at) as _ingested_at
+        MIN(_ingested_at) as _ingested_at,
+        MAX(_watermark_ingested_at) as _watermark_ingested_at
     FROM participants_with_thread_id
     GROUP BY thread_id, email, domain
 ),
@@ -67,7 +104,8 @@ SELECT
     ) as roles,
     first_participated_at,
     last_participated_at,
-    _ingested_at
+    _ingested_at,
+    _watermark_ingested_at
 FROM thread_participants
 ORDER BY thread_id, 
     CASE 
@@ -82,4 +120,3 @@ ORDER BY thread_id,
 )
 
 select * from final
-ORDER BY last_participated_at desc

--- a/models/sources/gmail/normalized/gmail_threads.sql
+++ b/models/sources/gmail/normalized/gmail_threads.sql
@@ -1,12 +1,40 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('gmail', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['thread_id']),
+    unique_key='thread_id',
+    on_schema_change='append_new_columns',
     tags=['gmail', 'normalized']
 ) }}
 
+{{ nexus.nexus_incremental_upgrade_guard(['_watermark_ingested_at', 'thread_id']) }}
+
 -- Cross-account normalized threads: Group per-account threads by first_message_id_header
-WITH per_account_threads AS (
+--
+-- Touched-group rollup. Child clock = the upstream rollup's
+-- _watermark_ingested_at (its _ingested_at is a frozen MIN). Known no-delete
+-- caveat: the group key IS first_message_id_header, so a late-arriving
+-- earlier message re-keys its thread — the new-key row is emitted correctly
+-- and the stale old-key row lingers until the next --full-refresh.
+WITH per_account_threads_all AS (
     SELECT * FROM {{ ref('gmail_threads_by_account') }}
+),
+
+{% if is_incremental() %}
+touched_thread_keys AS (
+    SELECT DISTINCT first_message_id_header
+    FROM per_account_threads_all
+    WHERE _watermark_ingested_at > {{ nexus.nexus_incremental_watermark_literal('_watermark_ingested_at') }}
+      AND first_message_id_header IS NOT NULL
+),
+{% endif %}
+
+per_account_threads AS (
+    SELECT t.* FROM per_account_threads_all t
+    {% if is_incremental() %}
+    INNER JOIN touched_thread_keys tk ON t.first_message_id_header = tk.first_message_id_header
+    {% endif %}
 ),
 
 grouped as (
@@ -43,6 +71,7 @@ grouped as (
             '}'
         ) as label_ids,
         MIN(_ingested_at) as _ingested_at,
+        MAX(_watermark_ingested_at) as _watermark_ingested_at,
     FROM per_account_threads
     WHERE first_message_id_header IS NOT NULL
     GROUP BY first_message_id_header
@@ -76,8 +105,8 @@ SELECT
     g.gmail_thread_ids,
     g.label_ids,
     al.all_label_ids,
-    g._ingested_at
+    g._ingested_at,
+    g._watermark_ingested_at
 FROM grouped g
 LEFT JOIN all_labels al
     ON g.thread_id = al.first_message_id_header
-ORDER BY g.last_message_sent_at DESC

--- a/models/sources/google_calendar/intermediate/google_calendar_event_events.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_event_events.sql
@@ -1,8 +1,14 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_id']),
+    unique_key='event_id',
+    on_schema_change='append_new_columns',
     tags=['nexus', 'google_calendar', 'intermediate', 'events']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'event_id']) }}
 
 -- Extract calendar events from normalized google_calendar_events
 SELECT
@@ -35,3 +41,6 @@ SELECT
     is_recurring
 FROM {{ ref('google_calendar_events_normalized') }}
 WHERE start_time IS NOT NULL
+{% if is_incremental() %}
+  AND _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+{% endif %}

--- a/models/sources/google_calendar/intermediate/google_calendar_event_relationship_declarations.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_event_relationship_declarations.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['relationship_declaration_id']),
+    unique_key='relationship_declaration_id',
+    on_schema_change='append_new_columns',
     tags=['nexus', 'google_calendar', 'intermediate', 'relationship_declarations']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'relationship_declaration_id']) }}
 
 -- Extract person→group relationships from google calendar event participants
 WITH participants AS (
     SELECT * FROM {{ ref('google_calendar_event_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 participants_with_nexus_event_id AS (
@@ -77,4 +86,3 @@ SELECT
     source,
     _ingested_at
 FROM relationships
-ORDER BY occurred_at DESC

--- a/models/sources/google_calendar/intermediate/google_calendar_group_identifiers.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_group_identifiers.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_identifier_id']),
+    unique_key='entity_identifier_id',
+    on_schema_change='append_new_columns',
     tags=['nexus', 'google_calendar', 'intermediate', 'group_identifiers']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_identifier_id']) }}
 
 -- Extract group (domain) identifiers from google calendar event participants
 WITH participants AS (
     SELECT * FROM {{ ref('google_calendar_event_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 participants_with_nexus_event_id AS (
@@ -71,4 +80,3 @@ redirected_domains AS (
 SELECT * FROM domain_identifiers
 UNION ALL
 SELECT * FROM redirected_domains
-ORDER BY occurred_at DESC

--- a/models/sources/google_calendar/intermediate/google_calendar_group_traits.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_group_traits.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_trait_id']),
+    unique_key='entity_trait_id',
+    on_schema_change='append_new_columns',
     tags=['nexus', 'google_calendar', 'intermediate', 'group_traits']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_trait_id']) }}
 
 -- Extract group (domain) traits from google calendar event participants
 WITH participants AS (
     SELECT * FROM {{ ref('google_calendar_event_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 participants_with_nexus_event_id AS (
@@ -51,4 +60,3 @@ domain_traits AS (
 )
 
 SELECT * FROM domain_traits
-ORDER BY occurred_at DESC

--- a/models/sources/google_calendar/intermediate/google_calendar_person_identifiers.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_person_identifiers.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_identifier_id']),
+    unique_key='entity_identifier_id',
+    on_schema_change='append_new_columns',
     tags=['nexus', 'google_calendar', 'intermediate', 'person_identifiers']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_identifier_id']) }}
 
 -- Extract person identifiers from google calendar event participants
 WITH participants AS (
     SELECT * FROM {{ ref('google_calendar_event_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 participants_with_event_id AS (
@@ -54,4 +63,3 @@ deduplicated AS (
 
 SELECT * FROM deduplicated
 WHERE identifier_value IS NOT NULL
-ORDER BY occurred_at DESC

--- a/models/sources/google_calendar/intermediate/google_calendar_person_traits.sql
+++ b/models/sources/google_calendar/intermediate/google_calendar_person_traits.sql
@@ -1,12 +1,21 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['entity_trait_id']),
+    unique_key='entity_trait_id',
+    on_schema_change='append_new_columns',
     tags=['nexus', 'google_calendar', 'intermediate', 'person_traits']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'entity_trait_id']) }}
 
 -- Extract person traits from google calendar event participants
 WITH participants AS (
     SELECT * FROM {{ ref('google_calendar_event_participants') }}
+    {% if is_incremental() %}
+    WHERE _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 participants_with_event_id AS (
@@ -72,4 +81,3 @@ deduplicated AS (
 )
 
 SELECT * FROM deduplicated
-ORDER BY occurred_at DESC

--- a/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_event_participants.sql
@@ -1,8 +1,14 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_id']),
+    unique_key=['event_id', 'email', 'role'],
+    on_schema_change='append_new_columns',
     tags=['google_calendar', 'normalized']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'event_id']) }}
 
 -- Normalized participants: Extract, parse, and normalize all participants (organizer, creator, attendees) from Google Calendar events
 -- Creates one row per participant per event, with role indicating "organizer", "creator", or "attendee"
@@ -39,6 +45,9 @@ WITH source_data AS (
         _raw_record
     FROM {{ ref('google_calendar_events_base_dedupped') }}
     WHERE JSON_EXTRACT_SCALAR(_raw_record, '$.id') IS NOT NULL
+    {% if is_incremental() %}
+      AND _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
       AND JSON_EXTRACT_SCALAR(_raw_record, '$.iCalUID') IS NOT NULL
 ),
 
@@ -232,11 +241,8 @@ SELECT
     start_time,
     _ingested_at
 FROM participants_combined
-ORDER BY event_id, 
-    CASE role 
-        WHEN 'organizer' THEN 1
-        WHEN 'creator' THEN 2
-        WHEN 'attendee' THEN 3
-    END,
-    normalized_email
-
+{# The raw feed can repeat an attendee within one event (no dedup existed
+   here historically); the merge needs one row per unique_key per batch. #}
+{% if is_incremental() %}
+QUALIFY row_number() OVER (PARTITION BY event_id, normalized_email, role ORDER BY _ingested_at DESC) = 1
+{% endif %}

--- a/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
+++ b/models/sources/google_calendar/normalized/google_calendar_events_normalized.sql
@@ -1,8 +1,14 @@
 {{ config(
     enabled=var('nexus', {}).get('sources', {}).get('google_calendar', {}).get('enabled', false),
-    materialized='table',
+    materialized=nexus.nexus_incremental_materialization(),
+    partition_by=nexus.nexus_bq_partition_by('_ingested_at', granularity='month'),
+    cluster_by=nexus.nexus_cluster_by(['event_id']),
+    unique_key='event_id',
+    on_schema_change='append_new_columns',
     tags=['google_calendar', 'normalized']
 ) }}
+
+{{ nexus.nexus_incremental_upgrade_guard(['_ingested_at', 'event_id']) }}
 
 -- Normalized layer: Clean, deduplicated events with explicit columns
 -- Extracts data from new STANDARD_TABLE_SCHEMA with _raw_record
@@ -22,6 +28,9 @@ WITH source_data AS (
     FROM {{ ref('google_calendar_events_base_dedupped') }}
     WHERE JSON_EXTRACT_SCALAR(_raw_record, '$.id') IS NOT NULL
       AND JSON_EXTRACT_SCALAR(_raw_record, '$.iCalUID') IS NOT NULL
+    {% if is_incremental() %}
+      AND _ingested_at > {{ nexus.nexus_incremental_watermark_literal('_ingested_at') }}
+    {% endif %}
 ),
 
 extracted AS (
@@ -156,5 +165,3 @@ SELECT
 FROM with_composite_key
 -- Deduplication: keep latest event per event_key (iCalUID for single, iCalUID + instanceStart for recurring)
 QUALIFY row_number() OVER (PARTITION BY event_key ORDER BY _ingested_at DESC) = 1
-ORDER BY start_time DESC
-


### PR DESCRIPTION
Part 2 of the Incremental dbt-nexus effort (v0.12 = incremental identity resolution). Converts the gmail/google_calendar source layers and the core event log to watermark-append incrementals. **Incremental-native**: no flag-off compile-parity gymnastics — existing clients are protected by their version pins (AWM: v0.11.11) and adopt via one `--full-refresh` when they bump (upgrade guards make any miss loud and self-explanatory).

## What's here
- **Append class** — the #588 finals recipe applied to the per-row gmail/gcal layers, including `gmail_messages_by_account` (the 9s model; its same-grain participant summary is filtered by the same single watermark literal).
- **Touched-group rollup pattern** (new; `nexus_incremental_touched_groups.sql`) for the six gmail GROUP BY models: batch → touched group keys (widened where grouping routes through other rollups) → recompute those groups from full upstream → merge on output grain. Cursor = unconditional `_watermark_ingested_at` (MAX child ingestion per group).
- **Rollup-child clock rule** — consumers of rollups batch on `_watermark_ingested_at`; fixes a live v0.12 bug where `gmail_thread_events` froze at a MIN-of-MIN stamp and `gmail_events` never re-merged threads that gained messages.
- **Core event log** — `nexus_events`, the measurement/dimension unions (with a compile-time `_ingested_at` contract naming offenders), and `nexus_entity_participants` with an append leg + a resolution-log-driven **repoint leg** (own cursor, self-healing across batches, ids stable at birth).
- **Portability/robustness fixes** found by the verification cycle: idempotent BQ PK hook (incremental tables persist; bare `ADD PRIMARY KEY` collided on run 2), `UNION DISTINCT` (BQ requires the keyword), gated duck `UNNEST(roles)` aliases.
- Docs section 7 in `incremental-identity-resolution.md`; harness now builds participants per scenario with two new invariants.

## Verification
- IT harness: **8/8 scenarios green** including the new participants invariants (no-live-losers, distinct-grain mapping parity).
- SRT duck: full epoch clean (260 models + 201 tests); steady rerun = **zero row changes across 220 tables**; injected one synthetic email → 36-model cone in **7.9s single-threaded** (was ~32s) with exactly the expected deltas; immediate rerun = no-op.
- BQ dev: sources + cone full-refresh clean; steady state clean; constraint hook verified across repeated incremental runs.

Tag `v0.13.0` after merge; SRT adopts in the companion nexus PR (pin bump + local-source conversions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFYpu9JDganJx12xMUrFzT